### PR TITLE
Fix Celsius sensor scaling for Poolsana e1kd83ng model

### DIFF
--- a/custom_components/tuya_heat_pump/models/e1kd83ng.py
+++ b/custom_components/tuya_heat_pump/models/e1kd83ng.py
@@ -13,7 +13,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     "effluent_temp": {
         "dp_id": 25,
@@ -23,7 +23,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     "return_temp": {
         "dp_id": 121,
@@ -33,7 +33,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     
     # ========== HEAT PUMP COMPONENT TEMPERATURES (Celsius) ==========
@@ -45,7 +45,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     "venting_temp": {
         "dp_id": 24,
@@ -55,7 +55,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     "around_temp": {
         "dp_id": 26,
@@ -65,7 +65,7 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
     "cool_coiler_temp": {
         "dp_id": 123,
@@ -75,7 +75,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
+        "conversion": "value / 10",
     },
 
     # ========== FAHRENHEIT VERSIONS (read-only) ==========


### PR DESCRIPTION
This changes the Celsius telemetry scaling for the Poolsana e1kd83ng model.

On affected devices, several live temperature sensors are reported in tenths of a degree, but are currently exposed as whole degrees. This leads to clearly invalid values such as inlet/outlet water temperatures around 96 °C / 110 °C and discharge temperatures around 406 °C.

This patch changes the following Celsius telemetry sensors from:

    "conversion": "value"

to:

    "conversion": "value / 10"

Affected sensors:
- temp_current
- effluent_temp
- return_temp
- coiler_temp
- venting_temp
- around_temp
- cool_coiler_temp

Setpoints already use /10 scaling and are unchanged.
Fahrenheit mappings are also left unchanged.

Observed examples on a running unit:
- temp_current: 96 -> 9.6 °C
- effluent_temp: 110 -> 11.0 °C
- venting_temp: 406 -> 40.6 °C
- coiler_temp: -52 -> -5.2 °C
- return_temp: -22 -> -2.2 °C

These corrected values are physically plausible and match normal heat pump operation.