### PR TITLE
Clean up conversion code.

### DIFF
--- a/custom_components/tuya_heat_pump/binary_sensor.py
+++ b/custom_components/tuya_heat_pump/binary_sensor.py
@@ -1,17 +1,21 @@
 """Binary sensor platform for Tuya Heatpump."""
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
 from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.config_entries import ConfigEntry
 
 from .const import DOMAIN
+from .conversion import Conversion
 from .coordinator import TuyaScaleDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -19,24 +23,34 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Tuya Heatpump binary sensors from a config entry."""
-    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
     binary_sensors = []
-    
+
     # Online status binary sensor - HER ZAMAN EKLE
     binary_sensors.append(TuyaHeatpumpOnlineSensor(coordinator))
     _LOGGER.info("Adding online status binary sensor")
-    
+
     # Model mapping'den binary sensörleri al
     binary_sensor_configs = coordinator.model_mapping.get("binary_sensors", {})
-    
+
     for sensor_code, sensor_config in binary_sensor_configs.items():
         if coordinator.data and sensor_code in coordinator.data:
-            binary_sensors.append(TuyaHeatpumpBinarySensor(coordinator, sensor_code, sensor_config))
-            _LOGGER.info("Adding binary sensor: %s (%s)", sensor_config.get('name', sensor_code), sensor_code)
+            binary_sensors.append(
+                TuyaHeatpumpBinarySensor(coordinator, sensor_code, sensor_config)
+            )
+            _LOGGER.info(
+                "Adding binary sensor: %s (%s)",
+                sensor_config.get("name", sensor_code),
+                sensor_code,
+            )
         else:
-            _LOGGER.warning("Binary sensor %s not found in device data, skipping", sensor_code)
-    
+            _LOGGER.warning(
+                "Binary sensor %s not found in device data, skipping", sensor_code
+            )
+
     async_add_entities(binary_sensors)
 
 
@@ -49,15 +63,17 @@ class TuyaHeatpumpOnlineSensor(BinarySensorEntity):
     ) -> None:
         """Initialize the online status binary sensor."""
         self.coordinator = coordinator
-        
+
         # Device name ile unique_id oluştur
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_online_status"
-        
+
         self._attr_name = "Online Status"
         self._attr_device_class = "connectivity"
         self._attr_has_entity_name = True
-        
+
         # Device info
         self._attr_device_info = coordinator.device_info
 
@@ -97,21 +113,23 @@ class TuyaHeatpumpBinarySensor(BinarySensorEntity):
         self,
         coordinator: TuyaScaleDataUpdateCoordinator,
         sensor_code: str,
-        config: dict
+        config: dict,
     ) -> None:
         """Initialize the binary sensor."""
         self.coordinator = coordinator
         self._sensor_code = sensor_code
         self._config = config
-        
+
         # Device name ile unique_id oluştur
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_{sensor_code}"
-        
-        self._attr_name = config.get('name', sensor_code)
-        self._attr_device_class = config.get('device_class')
+
+        self._attr_name = config.get("name", sensor_code)
+        self._attr_device_class = config.get("device_class")
         self._attr_has_entity_name = True
-        
+
         # Device info
         self._attr_device_info = coordinator.device_info
 
@@ -125,34 +143,33 @@ class TuyaHeatpumpBinarySensor(BinarySensorEntity):
         """Return true if the binary sensor is on."""
         if not self.coordinator.data or self._sensor_code not in self.coordinator.data:
             return None
-            
-        raw_value = self.coordinator.data[self._sensor_code]['value']
-        
-        # Conversion uygula
-        conversion = self._config.get('conversion', 'bool(value)')
+
+        raw_value = self.coordinator.data[self._sensor_code]["value"]
+
+        conversion = Conversion(self._config.get("conversion", "bool(value)"))
         try:
-            result = eval(conversion, {"value": raw_value, "__builtins__": {}})
+            result = conversion.convert(raw_value)
             return bool(result)
         except Exception as err:
             _LOGGER.warning("Conversion failed for %s: %s", self._sensor_code, err)
-            
+
             # Fallback conversion
             if isinstance(raw_value, bool):
                 return raw_value
             elif isinstance(raw_value, (int, float)):
                 return bool(raw_value)
             elif isinstance(raw_value, str):
-                return raw_value.lower() in ['true', '1', 'on', 'yes', 'enable', 'open']
-            
+                return raw_value.lower() in ["true", "1", "on", "yes", "enable", "open"]
+
             return False
 
     @property
     def available(self) -> bool:
         """Return if entity is available."""
         return (
-            self.coordinator.last_update_success and 
-            self.coordinator.data is not None and
-            self._sensor_code in self.coordinator.data
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self._sensor_code in self.coordinator.data
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/tuya_heat_pump/conversion.py
+++ b/custom_components/tuya_heat_pump/conversion.py
@@ -1,0 +1,16 @@
+class Conversion:
+    def __init__(self, conversion: str) -> None:
+        self.conversion = conversion
+
+    def convert(self, value):
+        eval(
+            self.conversion,
+            {
+                "value": value,
+                "__builtins__": {
+                    "bool": bool,
+                    "float": float,
+                    "int": int,
+                },
+            },
+        )

--- a/custom_components/tuya_heat_pump/models/000000324z.py
+++ b/custom_components/tuya_heat_pump/models/000000324z.py
@@ -13,7 +13,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "SpeedPercentage": {
         "dp_id": 104,
@@ -22,7 +21,6 @@ SENSOR_TYPES = {
         "unit": "%",
         "icon": "mdi:speedometer",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "SetDnLimit": {
         "dp_id": 107,
@@ -32,7 +30,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-down",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "SetUpLimit": {
         "dp_id": 108,
@@ -42,7 +39,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-up",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "OutPipeTemp": {
         "dp_id": 120,
@@ -52,7 +48,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ExhaustTemp": {
         "dp_id": 122,
@@ -62,7 +57,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "AmbTemp": {
         "dp_id": 124,
@@ -72,7 +66,6 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "CompFreAct": {
         "dp_id": 125,
@@ -81,7 +74,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:sine-wave",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "CompressorCurrent": {
         "dp_id": 126,
@@ -91,7 +83,6 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "RadTemp": {
         "dp_id": 127,
@@ -101,7 +92,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "EXVPosition": {
         "dp_id": 128,
@@ -110,7 +100,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "DCFanSpeed": {
         "dp_id": 129,
@@ -119,7 +108,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan",
         "state_class": "measurement",
-        "conversion": "value",
     },
     # ========== SETPOINTS (read-only for display) ==========
     "SetTemp": {
@@ -130,7 +118,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
 }
 
@@ -144,7 +131,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Fault Code 1",
         "icon": "mdi:alert-circle",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "fault2": {
         "dp_id": 116,
@@ -152,7 +139,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Fault Code 2",
         "icon": "mdi:alert-circle",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "WarmOrCool": {
         "dp_id": 118,
@@ -162,8 +149,8 @@ BINARY_SENSOR_TYPES = {
         "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
         "options": {
             False: "Heating",
-            True: "Cooling"
-        }
+            True: "Cooling",
+        },
     },
     "Defrost": {
         "dp_id": 130,
@@ -171,7 +158,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Defrost Status",
         "icon": "mdi:snowflake-melt",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "CompRly": {
         "dp_id": 134,
@@ -179,7 +166,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Compressor Contactor",
         "icon": "mdi:engine",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "CyclePump": {
         "dp_id": 135,
@@ -187,7 +174,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Circulation Pump",
         "icon": "mdi:water-pump",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "ReserveValve": {
         "dp_id": 136,
@@ -195,14 +182,14 @@ BINARY_SENSOR_TYPES = {
         "name": "Four-Way Valve",
         "icon": "mdi:valve",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "ChargeRly": {
         "dp_id": 139,
         "code": "ChargeRly",
         "name": "Charge Relay",
         "icon": "mdi:flash",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -215,7 +202,7 @@ SWITCH_TYPES = {
         "code": "Power",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "change_tem": {
         "dp_id": 103,
@@ -225,15 +212,15 @@ SWITCH_TYPES = {
         "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
         "options": {
             False: "Celsius",
-            True: "Fahrenheit"
-        }
+            True: "Fahrenheit",
+        },
     },
     "SilentMdoe": {
         "dp_id": 117,
         "code": "SilentMdoe",
         "name": "Silent Mode",
         "icon": "mdi:volume-off",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -250,8 +237,6 @@ NUMBER_TYPES = {
         "min_value": -22.0,
         "max_value": 104.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -265,11 +250,10 @@ SELECT_TYPES = {
         "name": "Mode",
         "icon": "mdi:hvac",
         "options": {
-            "smart": "Smart",
+            "smart": "Auto",
             "warm": "Heating",
-            "cool": "Cooling"
+            "cool": "Cooling",
         },
-        "conversion": "value"
     },
     "ACFanSpeed": {
         "dp_id": 140,
@@ -279,8 +263,7 @@ SELECT_TYPES = {
         "options": {
             "LowSpeed": "Low Speed",
             "MidSpeed": "Mid Speed",
-            "HighSpeed": "High Speed"
+            "HighSpeed": "High Speed",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/0000038m77.py
+++ b/custom_components/tuya_heat_pump/models/0000038m77.py
@@ -13,7 +13,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "AmbientTemp": {
         "dp_id": 102,
@@ -23,7 +22,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "OCT1": {
         "dp_id": 103,
@@ -33,7 +31,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "CTT": {
         "dp_id": 104,
@@ -43,7 +40,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ReturnAirTemp": {
         "dp_id": 105,
@@ -53,7 +49,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterTankTemp": {
         "dp_id": 106,
@@ -63,7 +58,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "OCT_Cool": {
         "dp_id": 107,
@@ -73,7 +67,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterInTemp": {
         "dp_id": 108,
@@ -83,7 +76,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterOutTemp": {
         "dp_id": 109,
@@ -93,7 +85,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ValveFrontTemp": {
         "dp_id": 110,
@@ -103,7 +94,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ValvePostTemp": {
         "dp_id": 111,
@@ -113,7 +103,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
 }
 
@@ -132,7 +121,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Compressor",
         "icon": "mdi:engine",
         "device_class": "running",
-        "conversion": "value",
     },
     "FouValve": {
         "dp_id": 113,
@@ -140,7 +128,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Four-Way Valve",
         "icon": "mdi:valve",
         "device_class": "opening",
-        "conversion": "value",
     },
     "Heat": {
         "dp_id": 114,
@@ -148,7 +135,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Electric Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value",
     },
     "Fan": {
         "dp_id": 115,
@@ -156,7 +142,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Fan",
         "icon": "mdi:fan",
         "device_class": "running",
-        "conversion": "value",
     },
     "Pumb": {
         "dp_id": 116,
@@ -164,7 +149,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Pump",
         "icon": "mdi:pump",
         "device_class": "running",
-        "conversion": "value",
     },
     "ChassisHeat": {
         "dp_id": 117,
@@ -172,7 +156,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Chassis Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value",
     },
     "CrankshaftHeat": {
         "dp_id": 118,
@@ -180,7 +163,6 @@ BINARY_SENSOR_TYPES = {
         "name": "Crankshaft Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value",
     },
 }
 
@@ -206,8 +188,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value",
     },
     "Temp_Offset": {
         "dp_id": 101,
@@ -218,8 +198,6 @@ NUMBER_TYPES = {
         "min_value": -9.0,
         "max_value": 9.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value",
     },
 }
 
@@ -236,6 +214,5 @@ SELECT_TYPES = {
             "eco": "Eco",
             "auto": "Auto",
         },
-        "conversion": "value",
     },
 }

--- a/custom_components/tuya_heat_pump/models/000003jtyb.py
+++ b/custom_components/tuya_heat_pump/models/000003jtyb.py
@@ -13,7 +13,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"  # Direkt °C
     },
 }
 
@@ -24,7 +23,7 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Alarm",
         "device_class": "problem",
-        "conversion": "value != 0"  # bitmap, 0 ise fault yok
+        "conversion": "value != 0",  # bitmap, 0 ise fault yok
     },
 }
 
@@ -35,7 +34,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -50,8 +49,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -69,9 +66,8 @@ SELECT_TYPES = {
             "eco_heat": "ECO Heat",
             "eco_cool": "ECO Cool",
             "silent_heat": "Silent Heat",
-            "silent_cool": "Silent Cool"
+            "silent_cool": "Silent Cool",
         },
-        "conversion": "value"
     },
     "freq": {
         "dp_id": 101,
@@ -81,8 +77,7 @@ SELECT_TYPES = {
         "options": {
             "silent": "Silent",
             "normal": "Normal",
-            "strong": "Strong"
+            "strong": "Strong",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/000003ynwv.py
+++ b/custom_components/tuya_heat_pump/models/000003ynwv.py
@@ -13,7 +13,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
     "temp_top": {
         "dp_id": 21,
@@ -23,7 +23,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_bottom": {
         "dp_id": 22,
@@ -33,7 +32,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "cur_current": {
         "dp_id": 102,
@@ -43,7 +41,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "voltage_current": {
         "dp_id": 103,
@@ -53,7 +51,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "cur_power": {
         "dp_id": 104,
@@ -63,7 +61,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "electric_total": {
         "dp_id": 105,
@@ -73,7 +71,7 @@ SENSOR_TYPES = {
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
 }
 
@@ -86,14 +84,14 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "defrost_state": {
         "dp_id": 33,
         "code": "defrost_state",
         "name": "Defrost State",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -106,7 +104,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -123,8 +121,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "water_set": {
         "dp_id": 10,
@@ -135,8 +131,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "minitemp_set": {
         "dp_id": 101,
@@ -147,8 +141,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "volume_set": {
         "dp_id": 106,
@@ -159,8 +151,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -180,9 +170,8 @@ SELECT_TYPES = {
             "hot_water": "Hot Water",
             "cold_and_hotwater": "Cool & Hot Water",
             "heating_and_hot_water": "Heat & Hot Water",
-            "floor_heatign_and_hot_water": "Floor Heat & Hot Water"
+            "floor_heatign_and_hot_water": "Floor Heat & Hot Water",
         },
-        "conversion": "value"
     },
     "work_mode": {
         "dp_id": 5,
@@ -191,9 +180,8 @@ SELECT_TYPES = {
         "icon": "mdi:cog",
         "options": {
             "ECO": "ECO",
-            "Normal": "Normal"
+            "Normal": "Normal",
         },
-        "conversion": "value"
     },
     "capacity_set": {
         "dp_id": 11,
@@ -205,9 +193,8 @@ SELECT_TYPES = {
             "H1": "H1",
             "H2": "H2",
             "H3": "H3",
-            "H4": "H4"
+            "H4": "H4",
         },
-        "conversion": "value"
     },
     "countdown_set": {
         "dp_id": 13,
@@ -231,8 +218,7 @@ SELECT_TYPES = {
             "L5": "L5",
             "L6": "L6",
             "L7": "L7",
-            "L8": "L8"
+            "L8": "L8",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/000004joyp.py
+++ b/custom_components/tuya_heat_pump/models/000004joyp.py
@@ -14,7 +14,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     # Speed Percentage
     "speedpercentage": {
@@ -24,7 +23,6 @@ SENSOR_TYPES = {
         "unit": "%",
         "icon": "mdi:speedometer",
         "state_class": "measurement",
-        "conversion": "value",
     },
     # Temperature Lower Limit
     "setdnlimit": {
@@ -35,7 +33,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-down",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     # Temperature Upper Limit
     "setuplimit": {
@@ -46,7 +43,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-up",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     # Power (with scale 3)
     "rateofwork": {
@@ -59,7 +55,6 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "conversion": "value / 1000",
     },
-    
     # ========== HATA KODU SENSÖRLERİ ==========
     # Fault 1 Code - Sadece hata kodu veya "OK"
     "fault1_code": {
@@ -120,7 +115,6 @@ SWITCH_TYPES = {
         "name": "Power",
         "icon": "mdi:power",
         "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
-        "api_conversion": "value",
     },
     # Temperature Unit (0=Celsius, 1=Fahrenheit)
     "change_tem": {
@@ -129,7 +123,6 @@ SWITCH_TYPES = {
         "name": "Temperature Unit",
         "icon": "mdi:thermometer",
         "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
-        "api_conversion": "value",
     },
 }
 
@@ -147,8 +140,6 @@ NUMBER_TYPES = {
         "min_value": -22.0,
         "max_value": 122.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value",
     },
 }
 
@@ -167,8 +158,6 @@ SELECT_TYPES = {
             "smart": "Smart",
             "booster": "Booster",
         },
-        "conversion": "value",
-        "api_conversion": "value",
     },
     # Operation Mode 2
     "setmode": {
@@ -181,8 +170,6 @@ SELECT_TYPES = {
             "warm": "Warm",
             "cool": "Cool",
         },
-        "conversion": "value",
-        "api_conversion": "value",
     },
     # Cooling Enable (read-only)
     "cool_en": {
@@ -194,8 +181,6 @@ SELECT_TYPES = {
             "0": "Disabled",
             "1": "Enabled",
         },
-        "conversion": "value",
-        "api_conversion": "value",
     },
     # Booster Enable (read-only)
     "booster_en": {
@@ -207,7 +192,5 @@ SELECT_TYPES = {
             "0": "Disabled",
             "1": "Enabled",
         },
-        "conversion": "value",
-        "api_conversion": "value",
     },
 }

--- a/custom_components/tuya_heat_pump/models/000004lh21.py
+++ b/custom_components/tuya_heat_pump/models/000004lh21.py
@@ -13,7 +13,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "out_water_temp": {
         "dp_id": 107,
@@ -23,7 +23,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "tank_temp": {
         "dp_id": 108,
@@ -33,7 +33,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "amb_temp": {
         "dp_id": 118,
@@ -43,7 +43,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "disc_temp": {
         "dp_id": 119,
@@ -53,7 +53,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "back_temp": {
         "dp_id": 120,
@@ -63,7 +63,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "comp_freq": {
         "dp_id": 121,
@@ -72,7 +72,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:cosine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "m_eev": {
         "dp_id": 122,
@@ -81,7 +80,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "a_eev": {
         "dp_id": 123,
@@ -90,7 +88,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:valve",
         "state_class": "measurement",
-        "conversion": "value"        
     },
     "dc_fan1": {
         "dp_id": 125,
@@ -99,7 +96,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-1",
         "state_class": "measurement",
-        "conversion": "value"        
     },
     "dc_fan2": {
         "dp_id": 126,
@@ -108,7 +104,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-2",
         "state_class": "measurement",
-        "conversion": "value"        
     },
     "flow_rate": {
         "dp_id": 127,
@@ -117,8 +112,8 @@ SENSOR_TYPES = {
         "unit": "m³/h",
         "icon": "mdi:gauge",
         "device_class": "volume_flow_rate",
-        "state_class": "measurement",        
-        "conversion": "value / 10"
+        "state_class": "measurement",
+        "conversion": "value / 10",
     },
     "ac_vol": {
         "dp_id": 128,
@@ -126,7 +121,7 @@ SENSOR_TYPES = {
         "name": "AC Voltage",
         "unit": "V",
         "device_class": "voltage",
-        "state_class": "measurement"
+        "state_class": "measurement",
     },
     "ac_curr": {
         "dp_id": 129,
@@ -135,7 +130,7 @@ SENSOR_TYPES = {
         "unit": "A",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "calculated_power": {
         "code": "calculated_power",
@@ -144,16 +139,14 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "total_energy": {
-        "code": "total_energy", 
+        "code": "total_energy",
         "name": "AC Total Energy",
         "unit": "Wh",
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value"
     },
     "tidr": {
         "dp_id": 181,
@@ -163,7 +156,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "fault": {
         "dp_id": 6,
@@ -179,42 +172,42 @@ BINARY_SENSOR_TYPES = {
         "code": "protect_flag",
         "name": "Protection",
         "device_class": "safety",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "freeze": {
         "dp_id": 114,
         "code": "freeze",
         "name": "Freeze Protection",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost": {
         "dp_id": 115,
         "code": "defrost",
         "name": "Defrost",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "pump_sta": {
         "dp_id": 116,
         "code": "pump_sta",
         "name": "Pump",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "valve": {
         "dp_id": 117,
         "code": "valve",
         "name": "4-Way Valve",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "fault_flag": {
         "dp_id": 130,
         "code": "fault_flag",
         "name": "Fault Flag",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -224,21 +217,21 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "mute": {
         "dp_id": 101,
         "code": "mute",
         "name": "Mute",
         "icon": "mdi:volume-off",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "holiday_sw": {
         "dp_id": 165,
         "code": "holiday_sw",
         "name": "Holiday Mode",
         "icon": "mdi:beach",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -377,7 +370,7 @@ SELECT_TYPES = {
             "auto": "Auto",
             "hot_water": "Hot Water",
             "cool_hot_water": "Cool & Hot Water",
-            "heat_hot_water": "Heat & Hot Water"
+            "heat_hot_water": "Heat & Hot Water",
         },
     },
     "zone_select": {
@@ -389,7 +382,7 @@ SELECT_TYPES = {
             "off": "Off",
             "szone1": "Zone 1",
             "szone2": "Zone 2",
-            "dzone": "Dual Zone"
+            "dzone": "Dual Zone",
         },
     },
 }

--- a/custom_components/tuya_heat_pump/models/000004u5nz.py
+++ b/custom_components/tuya_heat_pump/models/000004u5nz.py
@@ -12,7 +12,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:gauge",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "power_consumption": {
         "dp_id": 18,
@@ -22,7 +21,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
     "compressor_strength": {
         "dp_id": 20,
@@ -31,7 +30,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:cosine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_top": {
         "dp_id": 21,
@@ -41,7 +39,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_bottom": {
         "dp_id": 22,
@@ -51,7 +48,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp": {
         "dp_id": 23,
@@ -61,7 +57,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp": {
         "dp_id": 24,
@@ -71,7 +66,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp": {
         "dp_id": 25,
@@ -80,7 +74,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:gauge",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp": {
         "dp_id": 26,
@@ -90,7 +83,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_current_f": {
         "dp_id": 35,
@@ -100,7 +92,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "top_temp_f": {
         "dp_id": 36,
@@ -110,7 +101,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "bottom_temp_f": {
         "dp_id": 37,
@@ -120,7 +110,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp_f": {
         "dp_id": 38,
@@ -130,7 +119,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp_f": {
         "dp_id": 39,
@@ -139,7 +127,6 @@ SENSOR_TYPES = {
         "unit": "L/min",
         "icon": "mdi:water-pump",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp_f": {
         "dp_id": 40,
@@ -148,7 +135,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:fan",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp_f": {
         "dp_id": 41,
@@ -158,7 +144,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "cur_current": {
         "dp_id": 102,
@@ -168,7 +153,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "voltage_current": {
         "dp_id": 103,
@@ -178,7 +163,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "cur_power": {
         "dp_id": 104,
@@ -188,7 +173,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "electric_total": {
         "dp_id": 105,
@@ -198,7 +183,7 @@ SENSOR_TYPES = {
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
     "eviin": {
         "dp_id": 107,
@@ -208,7 +193,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "eviout": {
         "dp_id": 108,
@@ -218,7 +202,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "b_cur": {
         "dp_id": 109,
@@ -228,7 +211,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "c_cur": {
         "dp_id": 110,
@@ -238,7 +221,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "bv": {
         "dp_id": 111,
@@ -248,7 +231,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "cv": {
         "dp_id": 112,
@@ -258,7 +241,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     # Hesaplanan sensörler
     "calculated_total_power": {
@@ -268,7 +251,6 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "countdown_left": {  # Bu sensör olmalı (ro)
         "dp_id": 14,
@@ -277,7 +259,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:chip",
         "state_class": "measurement",
-        "conversion": "value"
     },
 }
 
@@ -288,28 +269,28 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "compressor_state": {
         "dp_id": 27,
         "code": "compressor_state",
         "name": "Compressor State",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "backwater": {
         "dp_id": 31,
         "code": "backwater",
         "name": "Hot Water Mode",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost_state": {
         "dp_id": 33,
         "code": "defrost_state",
         "name": "Defrost State",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -320,7 +301,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -335,8 +316,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "water_set": {  # accessMode: "rw"
         "dp_id": 10,
@@ -347,8 +326,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "minitemp_set": {  # accessMode: "rw"
         "dp_id": 101,
@@ -359,8 +336,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "volume_set": {  # accessMode: "rw"
         "dp_id": 106,
@@ -371,8 +346,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 2.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -390,9 +363,8 @@ SELECT_TYPES = {
             "hot_water": "Hot Water",
             "cold_and_hotwater": "Cool & Hot Water",
             "heating_and_hot_water": "Heat & Hot Water",
-            "floor_heatign_and_hot_water": "Floor Heat & Hot Water"
+            "floor_heatign_and_hot_water": "Floor Heat & Hot Water",
         },
-        "conversion": "value"
     },
     "work_mode": {  # accessMode: "rw"
         "dp_id": 5,
@@ -402,9 +374,8 @@ SELECT_TYPES = {
         "options": {
             "ECO": "ECO",
             "Normal": "Normal",
-            "Boost": "Boost"
+            "Boost": "Boost",
         },
-        "conversion": "value"
     },
     "capacity_set": {  # accessMode: "rw"
         "dp_id": 11,
@@ -416,9 +387,8 @@ SELECT_TYPES = {
             "H1": "H1",
             "H2": "H2",
             "H3": "H3",
-            "H4": "H4"
+            "H4": "H4",
         },
-        "conversion": "value"
     },
     "countdown_set": {  # accessMode: "rw"
         "dp_id": 13,
@@ -442,8 +412,7 @@ SELECT_TYPES = {
             "L5": "L5",
             "L6": "L6",
             "L7": "L7",
-            "L8": "L8"
+            "L8": "L8",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/000004wtcv.py
+++ b/custom_components/tuya_heat_pump/models/000004wtcv.py
@@ -13,7 +13,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "out_water_temp": {
         "dp_id": 107,
@@ -23,7 +23,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "tank_temp": {
         "dp_id": 108,
@@ -33,7 +33,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "amb_temp": {
         "dp_id": 118,
@@ -43,7 +43,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "disc_temp": {
         "dp_id": 119,
@@ -53,7 +53,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "back_temp": {
         "dp_id": 120,
@@ -63,7 +63,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "flow_rate": {
         "dp_id": 127,
@@ -73,7 +73,7 @@ SENSOR_TYPES = {
         "icon": "mdi:gauge",
         "device_class": None,  # Fixed: pressure yerine None
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "tidr": {
         "dp_id": 181,
@@ -83,7 +83,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "comp_freq": {
         "dp_id": 121,
@@ -92,7 +92,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:cosine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "m_eev": {
         "dp_id": 122,
@@ -101,7 +100,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "a_eev": {
         "dp_id": 123,
@@ -110,7 +108,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "dc_fan1": {
         "dp_id": 125,
@@ -119,7 +116,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-1",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "dc_fan2": {
         "dp_id": 126,
@@ -128,7 +124,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-2",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "ac_vol": {
         "dp_id": 128,
@@ -138,7 +133,6 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "ac_curr": {
         "dp_id": 129,
@@ -148,7 +142,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "calculated_power": {
         "code": "calculated_power",
@@ -157,16 +151,14 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "total_energy": {
-        "code": "total_energy", 
+        "code": "total_energy",
         "name": "AC Total Energy",
         "unit": "Wh",
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value"
     },
 }
 
@@ -177,49 +169,49 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "protect_flag": {
         "dp_id": 110,
         "code": "protect_flag",
         "name": "Protection Status",
         "device_class": "safety",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "freeze": {
         "dp_id": 114,
         "code": "freeze",
         "name": "Freeze Status",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost": {
         "dp_id": 115,
         "code": "defrost",
         "name": "Defrost Status",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "pump_sta": {
         "dp_id": 116,
         "code": "pump_sta",
         "name": "Pump Status",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "valve": {
         "dp_id": 117,
         "code": "valve",
         "name": "Valve Status",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "fault_flag": {
         "dp_id": 130,
         "code": "fault_flag",
         "name": "Fault Flag",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -230,21 +222,21 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "mute": {
         "dp_id": 101,
-        "code": "mute", 
+        "code": "mute",
         "name": "Mute",
         "icon": "mdi:volume-off",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "holiday_sw": {
         "dp_id": 165,
         "code": "holiday_sw",
-        "name": "Holiday Mode", 
+        "name": "Holiday Mode",
         "icon": "mdi:beach",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -260,11 +252,11 @@ NUMBER_TYPES = {
         "max_value": 25.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"  # HA → API için ters dönüşüm
+        "api_conversion": "value * 10",  # HA → API için ters dönüşüm
     },
     "heat_temp_set": {
         "dp_id": 103,
-        "code": "heat_temp_set", 
+        "code": "heat_temp_set",
         "name": "Heat Temperature Set",
         "icon": "mdi:thermometer",
         "unit": "°C",
@@ -272,31 +264,31 @@ NUMBER_TYPES = {
         "max_value": 65.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "hot_water_temp_set": {
         "dp_id": 104,
         "code": "hot_water_temp_set",
-        "name": "Hot Water Temperature Set", 
+        "name": "Hot Water Temperature Set",
         "icon": "mdi:water-thermometer",
         "unit": "°C",
         "min_value": 25.0,
         "max_value": 60.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "auto_temp_set": {
         "dp_id": 105,
         "code": "auto_temp_set",
         "name": "Auto Temperature Set",
         "icon": "mdi:thermometer-auto",
-        "unit": "°C", 
+        "unit": "°C",
         "min_value": 7.0,
         "max_value": 60.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
 }
 
@@ -309,13 +301,12 @@ SELECT_TYPES = {
         "icon": "mdi:air-conditioner",
         "options": {
             "cool": "Cool",
-            "heat": "Heat", 
+            "heat": "Heat",
             "auto": "Auto",
             "hot_water": "Hot Water",
             "cool_hot_water": "Cool & Hot Water",
             "heat_hot_water": "Heat & Hot Water",
-            "auto_dhw": "Auto DHW"
+            "auto_dhw": "Auto DHW",
         },
-        "conversion": "value"
     }
 }

--- a/custom_components/tuya_heat_pump/models/default.py
+++ b/custom_components/tuya_heat_pump/models/default.py
@@ -13,7 +13,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "out_water_temp": {
         "dp_id": 107,
@@ -23,7 +23,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "tank_temp": {
         "dp_id": 108,
@@ -33,7 +33,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "amb_temp": {
         "dp_id": 118,
@@ -43,7 +43,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "disc_temp": {
         "dp_id": 119,
@@ -53,7 +53,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "back_temp": {
         "dp_id": 120,
@@ -63,7 +63,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "flow_rate": {
         "dp_id": 127,
@@ -73,7 +73,7 @@ SENSOR_TYPES = {
         "icon": "mdi:gauge",
         "device_class": None,  # Fixed: pressure yerine None
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "tidr": {
         "dp_id": 181,
@@ -83,7 +83,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "comp_freq": {
         "dp_id": 121,
@@ -92,7 +92,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:cosine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "m_eev": {
         "dp_id": 122,
@@ -101,7 +100,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "a_eev": {
         "dp_id": 123,
@@ -110,7 +108,6 @@ SENSOR_TYPES = {
         "unit": "step",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "dc_fan1": {
         "dp_id": 125,
@@ -119,7 +116,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-1",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "dc_fan2": {
         "dp_id": 126,
@@ -128,7 +124,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan-speed-2",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "ac_vol": {
         "dp_id": 128,
@@ -138,7 +133,6 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "ac_curr": {
         "dp_id": 129,
@@ -148,7 +142,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "calculated_power": {
         "code": "calculated_power",
@@ -157,16 +151,14 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "total_energy": {
-        "code": "total_energy", 
+        "code": "total_energy",
         "name": "AC Total Energy",
         "unit": "Wh",
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value"
     },
 }
 
@@ -177,49 +169,49 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "protect_flag": {
         "dp_id": 110,
         "code": "protect_flag",
         "name": "Protection Status",
         "device_class": "safety",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "freeze": {
         "dp_id": 114,
         "code": "freeze",
         "name": "Freeze Status",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost": {
         "dp_id": 115,
         "code": "defrost",
         "name": "Defrost Status",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "pump_sta": {
         "dp_id": 116,
         "code": "pump_sta",
         "name": "Pump Status",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "valve": {
         "dp_id": 117,
         "code": "valve",
         "name": "Valve Status",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "fault_flag": {
         "dp_id": 130,
         "code": "fault_flag",
         "name": "Fault Flag",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -230,21 +222,21 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "mute": {
         "dp_id": 101,
-        "code": "mute", 
+        "code": "mute",
         "name": "Mute",
         "icon": "mdi:volume-off",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "holiday_sw": {
         "dp_id": 165,
         "code": "holiday_sw",
-        "name": "Holiday Mode", 
+        "name": "Holiday Mode",
         "icon": "mdi:beach",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -260,11 +252,11 @@ NUMBER_TYPES = {
         "max_value": 25.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"  # HA → API için ters dönüşüm
+        "api_conversion": "value * 10",  # HA → API için ters dönüşüm
     },
     "heat_temp_set": {
         "dp_id": 103,
-        "code": "heat_temp_set", 
+        "code": "heat_temp_set",
         "name": "Heat Temperature Set",
         "icon": "mdi:thermometer",
         "unit": "°C",
@@ -272,31 +264,31 @@ NUMBER_TYPES = {
         "max_value": 65.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "hot_water_temp_set": {
         "dp_id": 104,
         "code": "hot_water_temp_set",
-        "name": "Hot Water Temperature Set", 
+        "name": "Hot Water Temperature Set",
         "icon": "mdi:water-thermometer",
         "unit": "°C",
         "min_value": 25.0,
         "max_value": 60.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "auto_temp_set": {
         "dp_id": 105,
         "code": "auto_temp_set",
         "name": "Auto Temperature Set",
         "icon": "mdi:thermometer-auto",
-        "unit": "°C", 
+        "unit": "°C",
         "min_value": 7.0,
         "max_value": 60.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
 }
 
@@ -309,13 +301,12 @@ SELECT_TYPES = {
         "icon": "mdi:air-conditioner",
         "options": {
             "cool": "Cool",
-            "heat": "Heat", 
+            "heat": "Heat",
             "auto": "Auto",
             "hot_water": "Hot Water",
             "cool_hot_water": "Cool & Hot Water",
             "heat_hot_water": "Heat & Hot Water",
-            "auto_dhw": "Auto DHW"
+            "auto_dhw": "Auto DHW",
         },
-        "conversion": "value"
     }
 }

--- a/custom_components/tuya_heat_pump/models/e1kcc5hw.py
+++ b/custom_components/tuya_heat_pump/models/e1kcc5hw.py
@@ -12,7 +12,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:chip",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_current": {
         "dp_id": 16,
@@ -21,7 +20,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:gauge",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "power_consumption": {
         "dp_id": 18,
@@ -31,7 +29,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
     "compressor_strength": {
         "dp_id": 20,
@@ -40,7 +38,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:cosine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_top": {
         "dp_id": 21,
@@ -50,7 +47,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_bottom": {
         "dp_id": 22,
@@ -60,7 +56,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp": {
         "dp_id": 23,
@@ -70,7 +65,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp": {
         "dp_id": 24,
@@ -80,7 +74,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp": {
         "dp_id": 25,
@@ -89,7 +82,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:gauge",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp": {
         "dp_id": 26,
@@ -99,7 +91,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_current_f": {
         "dp_id": 35,
@@ -109,7 +100,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "top_temp_f": {
         "dp_id": 36,
@@ -119,7 +109,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "bottom_temp_f": {
         "dp_id": 37,
@@ -129,7 +118,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp_f": {
         "dp_id": 38,
@@ -139,7 +127,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp_f": {
         "dp_id": 39,
@@ -148,7 +135,6 @@ SENSOR_TYPES = {
         "unit": "L/min",
         "icon": "mdi:water-pump",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp_f": {
         "dp_id": 40,
@@ -157,7 +143,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:fan",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp_f": {
         "dp_id": 41,
@@ -167,7 +152,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "cur_current": {
         "dp_id": 102,
@@ -177,7 +161,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "voltage_current": {
         "dp_id": 103,
@@ -187,7 +171,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "cur_power": {
         "dp_id": 104,
@@ -197,7 +181,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "electric_total": {
         "dp_id": 105,
@@ -207,7 +191,7 @@ SENSOR_TYPES = {
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"
+        "conversion": "value / 100",
     },
     "eviin": {
         "dp_id": 107,
@@ -217,7 +201,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "eviout": {
         "dp_id": 108,
@@ -227,7 +210,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "b_cur": {
         "dp_id": 109,
@@ -237,7 +219,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "c_cur": {
         "dp_id": 110,
@@ -247,7 +229,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"
+        "conversion": "value / 1000",
     },
     "bv": {
         "dp_id": 111,
@@ -257,7 +239,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "cv": {
         "dp_id": 112,
@@ -267,7 +249,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "room_temp": {
         "dp_id": 113,
@@ -277,7 +259,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     # Hesaplanan sensörler
     "calculated_total_power": {
@@ -287,7 +268,6 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value"
     },
 }
 
@@ -300,35 +280,35 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status",
         "device_class": "problem",
-        "conversion": "value != 0"  # bitmap, 0 ise hata yok
+        "conversion": "value != 0",  # bitmap, 0 ise hata yok
     },
     "compressor_state": {
         "dp_id": 27,
         "code": "compressor_state",
         "name": "Compressor State",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "backwater": {
         "dp_id": 31,
         "code": "backwater",
         "name": "Hot Water Mode",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost_state": {
         "dp_id": 33,
         "code": "defrost_state",
         "name": "Defrost State",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "flag_room_temp": {
         "dp_id": 114,
         "code": "flag_room_temp",
         "name": "Room Temperature Flag",
         "device_class": "problem",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -341,7 +321,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -358,8 +338,6 @@ NUMBER_TYPES = {
         "min_value": -20.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "water_set": {
         "dp_id": 10,
@@ -370,8 +348,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "minitemp_set": {
         "dp_id": 101,
@@ -382,8 +358,6 @@ NUMBER_TYPES = {
         "min_value": 5.0,
         "max_value": 80.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "volume_set": {
         "dp_id": 106,
@@ -394,8 +368,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 2.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -415,9 +387,8 @@ SELECT_TYPES = {
             "hot_water": "Hot Water",
             "cold_and_hotwater": "Cool & Hot Water",
             "heating_and_hot_water": "Heat & Hot Water",
-            "floor_heatign_and_hot_water": "Floor Heat & Hot Water"
+            "floor_heatign_and_hot_water": "Floor Heat & Hot Water",
         },
-        "conversion": "value"
     },
     "work_mode": {
         "dp_id": 5,
@@ -427,9 +398,8 @@ SELECT_TYPES = {
         "options": {
             "ECO": "ECO",
             "Normal": "Normal",
-            "Boost": "Boost"
+            "Boost": "Boost",
         },
-        "conversion": "value"
     },
     "capacity_set": {
         "dp_id": 11,
@@ -441,9 +411,8 @@ SELECT_TYPES = {
             "H1": "H1",
             "H2": "H2",
             "H3": "H3",
-            "H4": "H4"
+            "H4": "H4",
         },
-        "conversion": "value"
     },
     "countdown_set": {
         "dp_id": 13,
@@ -467,8 +436,7 @@ SELECT_TYPES = {
             "L5": "L5",
             "L6": "L6",
             "L7": "L7",
-            "L8": "L8"
+            "L8": "L8",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/e1kd83ng.py
+++ b/custom_components/tuya_heat_pump/models/e1kd83ng.py
@@ -35,7 +35,6 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "conversion": "value / 10",
     },
-    
     # ========== HEAT PUMP COMPONENT TEMPERATURES (Celsius) ==========
     "coiler_temp": {
         "dp_id": 23,
@@ -77,7 +76,6 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "conversion": "value / 10",
     },
-
     # ========== FAHRENHEIT VERSIONS (read-only) ==========
     "temp_current_f": {
         "dp_id": 35,
@@ -87,7 +85,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "effluent_temp_f": {
         "dp_id": 40,
@@ -97,7 +94,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "return_temp_f": {
         "dp_id": 122,
@@ -107,7 +103,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "coiler_temp_f": {
         "dp_id": 41,
@@ -117,7 +112,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "venting_temp_f": {
         "dp_id": 39,
@@ -127,7 +121,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "around_temp_f": {
         "dp_id": 38,
@@ -137,7 +130,6 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "cool_coiler_temp_f": {
         "dp_id": 124,
@@ -147,22 +139,18 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
-
     # ========== UNIT INFORMATION ==========
     "unit_type": {
         "dp_id": 109,
         "code": "unit_type",
         "name": "Unit Type",
         "icon": "mdi:information",
-        "conversion": "value",
         "options": {
             0: "Standard",
-            1: "Inverter"
-        }
+            1: "Inverter",
+        },
     },
-    
     # ========== VALVE POSITION ==========
     "opening": {
         "dp_id": 125,
@@ -171,24 +159,20 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value",
     },
-    
     # ========== WORK STATE (read-only enum - accessMode: "ro") ==========
     "work_state": {
         "dp_id": 17,
         "code": "work_state",
         "name": "Work State",
         "icon": "mdi:state-machine",
-        "conversion": "value",
         "options": {
             "Running": "Running",
             "Defrosting": "Defrosting",
             "Standby": "Standby",
-            "Fault": "Fault"
-        }
+            "Fault": "Fault",
+        },
     },
-    
     # ========== TEMPERATURE SETPOINTS (read-only for display) ==========
     "set_heating_temp": {
         "dp_id": 101,
@@ -228,7 +212,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "set_cold_temp_f": {
         "dp_id": 106,
@@ -238,7 +221,6 @@ SENSOR_TYPES = {
         "icon": "mdi:snowflake",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "set_auto_temp_f": {
         "dp_id": 108,
@@ -248,7 +230,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat-auto",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
 }
 
@@ -262,7 +243,7 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Alarm",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     # Detailed Fault Code Tables
     "new_fault_01": {
@@ -270,28 +251,28 @@ BINARY_SENSOR_TYPES = {
         "code": "new_fault_01",
         "name": "Fault Code Table 1",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "new_fault_02": {
         "dp_id": 107,
         "code": "new_fault_02",
         "name": "Fault Code Table 2",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "fault_2": {
         "dp_id": 118,
         "code": "fault_2",
         "name": "Fault Alarm 2",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "fault_3": {
         "dp_id": 119,
         "code": "fault_3",
         "name": "Fault Alarm 3",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     # Driver Faults
     "new_driver_fault_01": {
@@ -299,21 +280,21 @@ BINARY_SENSOR_TYPES = {
         "code": "new_driver_fault_01",
         "name": "Driver Fault Code Table 1",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "new_driver_fault_02": {
         "dp_id": 111,
         "code": "new_driver_fault_02",
         "name": "Driver Fault Code Table 2",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "driver_fault_1": {
         "dp_id": 120,
         "code": "driver_fault_1",
         "name": "Driver Fault",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
 }
 
@@ -326,7 +307,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -344,7 +325,7 @@ NUMBER_TYPES = {
         "max_value": 40.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "set_cold_temp": {
         "dp_id": 102,
@@ -356,7 +337,7 @@ NUMBER_TYPES = {
         "max_value": 28.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "set_auto_temp": {
         "dp_id": 104,
@@ -368,7 +349,7 @@ NUMBER_TYPES = {
         "max_value": 40.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
     "set_heating_temp_f": {
         "dp_id": 105,
@@ -379,8 +360,6 @@ NUMBER_TYPES = {
         "min_value": 59.0,
         "max_value": 104.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "set_cold_temp_f": {
         "dp_id": 106,
@@ -391,8 +370,6 @@ NUMBER_TYPES = {
         "min_value": 46.0,
         "max_value": 82.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "set_auto_temp_f": {
         "dp_id": 108,
@@ -403,8 +380,6 @@ NUMBER_TYPES = {
         "min_value": 46.0,
         "max_value": 104.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -425,9 +400,8 @@ SELECT_TYPES = {
             "Heating_Smart": "Heating (Smart)",
             "Cooling_Smart": "Cooling (Smart)",
             "Heating_Silent": "Heating (Silent)",
-            "Cooling_Silent": "Cooling (Silent)"
+            "Cooling_Silent": "Cooling (Silent)",
         },
-        "conversion": "value"
     },
     # Work Mode (Cool/Heat/Auto)
     "work_mode": {
@@ -438,9 +412,8 @@ SELECT_TYPES = {
         "options": {
             "Cool_mode": "Cooling",
             "Heat_mode": "Heating",
-            "Auto_mode": "Auto"
+            "Auto_mode": "Auto",
         },
-        "conversion": "value"
     },
     # Temperature Unit
     "temp_unit_convert": {
@@ -450,9 +423,8 @@ SELECT_TYPES = {
         "icon": "mdi:thermometer",
         "options": {
             "c": "Celsius",
-            "f": "Fahrenheit"
+            "f": "Fahrenheit",
         },
-        "conversion": "value"
     },
     # Frequency Mode (read-write enum)
     "frequency": {
@@ -463,8 +435,7 @@ SELECT_TYPES = {
         "options": {
             "Silent": "Silent",
             "Smart": "Smart",
-            "Powerful": "Powerful"
+            "Powerful": "Powerful",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/e1kvebno.py
+++ b/custom_components/tuya_heat_pump/models/e1kvebno.py
@@ -20,13 +20,12 @@ SENSOR_TYPES = {
         "code": "machine_type",
         "name": "Machine Type",
         "icon": "mdi:information",
-        "conversion": "value",
         "options": {
             0: "Mini (eh/ec)",
             1: "4 Mode (bh/eh/ec/auto)",
             2: "7 Mode (bh/eh/sh/bc/ec/sc/auto)",
-            3: "ZK 4 Mode (eh/sh/ec/auto)"
-        }
+            3: "ZK 4 Mode (eh/sh/ec/auto)",
+        },
     },
     "temp_up": {
         "dp_id": 102,
@@ -36,7 +35,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-up",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_low": {
         "dp_id": 103,
@@ -46,7 +44,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-down",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "fault": {
         "dp_id": 20,
@@ -54,7 +51,6 @@ SENSOR_TYPES = {
         "name": "Fault Codes",
         "icon": "mdi:alert-circle",
         "device_class": "problem",
-        "conversion": "value",
         "options": {
             1: "E01 - Phase Error",
             2: "E02 - Phase Loss",
@@ -80,7 +76,7 @@ SENSOR_TYPES = {
             2097152: "E42 - Cooling Coil Sensor Fault",
             4194304: "E44 - Low Ambient Temp Protection",
             8388608: "E45 - High Ambient Temp Protection",
-        }
+        },
     },
 }
 
@@ -96,8 +92,8 @@ BINARY_SENSOR_TYPES = {
         "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
         "options": {
             True: "Celsius",
-            False: "Fahrenheit"
-        }
+            False: "Fahrenheit",
+        },
     },
 }
 
@@ -110,7 +106,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -127,8 +123,6 @@ NUMBER_TYPES = {
         "min_value": 8.0,
         "max_value": 40.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -148,8 +142,7 @@ SELECT_TYPES = {
             "bcool": "Powerful Cooling",
             "ecool": "Smart Cooling",
             "scool": "Silent Cooling",
-            "auto": "Auto"
+            "auto": "Auto",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/e1mnja6s.py
+++ b/custom_components/tuya_heat_pump/models/e1mnja6s.py
@@ -13,7 +13,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_current_f": {
         "dp_id": 35,
@@ -23,7 +22,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "indoor_sensor_temperature": {
         "dp_id": 101,
@@ -33,7 +31,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "odd_hot_water": {
         "dp_id": 102,
@@ -42,7 +39,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:water",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "out_air_sensor_temp": {
         "dp_id": 107,
@@ -52,7 +48,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "evap_temperature": {
         "dp_id": 108,
@@ -62,7 +57,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "in_air_sensor_temperature": {
         "dp_id": 109,
@@ -72,7 +66,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "fan1_speed": {
         "dp_id": 112,
@@ -81,7 +74,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "compressor_frequency": {
         "dp_id": 113,
@@ -90,7 +82,6 @@ SENSOR_TYPES = {
         "unit": "Hz",
         "icon": "mdi:sine-wave",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "software_v_display_board": {
         "dp_id": 114,
@@ -99,7 +90,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:chip",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "software_v_main_board": {
         "dp_id": 115,
@@ -108,7 +98,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:chip",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "cooling_temperature": {
         "dp_id": 116,
@@ -118,7 +107,6 @@ SENSOR_TYPES = {
         "icon": "mdi:snowflake",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "set_temp_lower_limit": {
         "dp_id": 121,
@@ -127,7 +115,6 @@ SENSOR_TYPES = {
         "unit": "°C",
         "icon": "mdi:thermometer-chevron-down",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "set_temp_upper_limit": {
         "dp_id": 122,
@@ -136,7 +123,6 @@ SENSOR_TYPES = {
         "unit": "°C",
         "icon": "mdi:thermometer-chevron-up",
         "state_class": "measurement",
-        "conversion": "value"
     },
 }
 
@@ -149,14 +135,14 @@ BINARY_SENSOR_TYPES = {
         "code": "compressor_status",
         "name": "Compressor Status",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "aux_elec_heating_status": {
         "dp_id": 104,
         "code": "aux_elec_heating_status",
         "name": "Auxiliary Electric Heating Status",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -169,112 +155,112 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "child_lock": {
         "dp_id": 3,
         "code": "child_lock",
         "name": "Child Lock",
         "icon": "mdi:lock",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "silent_heating_status": {
         "dp_id": 106,
         "code": "silent_heating_status",
         "name": "MUTE Mode",
         "icon": "mdi:volume-off",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "auxiliary_heating_status": {
         "dp_id": 117,
         "code": "auxiliary_heating_status",
         "name": "BOOST Mode",
         "icon": "mdi:rocket-launch",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "cooling_mode_switch": {
         "dp_id": 118,
         "code": "cooling_mode_switch",
         "name": "Cooling Mode",
         "icon": "mdi:snowflake",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "cool_mode_lock_status": {
         "dp_id": 120,
         "code": "cool_mode_lock_status",
         "name": "Cooling Mode Lock Status",
         "icon": "mdi:lock",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "fast_recover": {
         "dp_id": 123,
         "code": "fast_recover",
         "name": "Fast Recovery",
         "icon": "mdi:speedometer",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "off_peak_period_scheme": {
         "dp_id": 124,
         "code": "off_peak_period_scheme",
         "name": "Week Execution Consistency",
         "icon": "mdi:calendar-clock",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "lock_device": {
         "dp_id": 125,
         "code": "lock_device",
         "name": "Device Lock",
         "icon": "mdi:lock",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_mon": {
         "dp_id": 186,
         "code": "checked_status_mon",
         "name": "Monday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_tue": {
         "dp_id": 187,
         "code": "checked_status_tue",
         "name": "Tuesday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_wed": {
         "dp_id": 188,
         "code": "checked_status_wed",
         "name": "Wednesday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_thu": {
         "dp_id": 189,
         "code": "checked_status_thu",
         "name": "Thursday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_fri": {
         "dp_id": 190,
         "code": "checked_status_fri",
         "name": "Friday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_sat": {
         "dp_id": 191,
         "code": "checked_status_sat",
         "name": "Saturday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "checked_status_sun": {
         "dp_id": 192,
         "code": "checked_status_sun",
         "name": "Sunday Status",
         "icon": "mdi:calendar",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -291,8 +277,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 176.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "mute_start_time": {
         "dp_id": 150,
@@ -303,8 +287,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1440.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "mute_end_time": {
         "dp_id": 151,
@@ -315,8 +297,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 1440.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -333,9 +313,8 @@ SELECT_TYPES = {
             "0": "Mode 0",
             "1": "Mode 1",
             "2": "Mode 2",
-            "3": "Mode 3"
+            "3": "Mode 3",
         },
-        "conversion": "value"
     },
     "temp_unit": {
         "dp_id": 119,
@@ -344,8 +323,7 @@ SELECT_TYPES = {
         "icon": "mdi:thermometer",
         "options": {
             "0": "Celsius",
-            "1": "Fahrenheit"
+            "1": "Fahrenheit",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/e8d6pg.py
+++ b/custom_components/tuya_heat_pump/models/e8d6pg.py
@@ -14,7 +14,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "AmbientTemp": {
         "dp_id": 102,
@@ -24,7 +23,6 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "OCT1": {
         "dp_id": 103,
@@ -34,7 +32,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "CTT": {
         "dp_id": 104,
@@ -44,7 +41,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ReturnAirTemp": {
         "dp_id": 105,
@@ -54,7 +50,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterTankTemp": {
         "dp_id": 106,
@@ -64,7 +59,6 @@ SENSOR_TYPES = {
         "icon": "mdi:water-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "OCT_Cool": {
         "dp_id": 107,
@@ -74,7 +68,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterInTemp": {
         "dp_id": 108,
@@ -84,7 +77,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "WaterOutTemp": {
         "dp_id": 109,
@@ -94,7 +86,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ValveFrontTemp": {
         "dp_id": 110,
@@ -104,7 +95,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "ValvePostTemp": {
         "dp_id": 111,
@@ -114,9 +104,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
-    
     # ========== SETPOINTS (read-only for display) ==========
     "temp_set": {
         "dp_id": 2,
@@ -126,7 +114,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",  # API 28 → 28°C
+        # API 28 → 28°C
     },
     "Temp_Offset": {
         "dp_id": 101,
@@ -136,7 +124,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-plus",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",  # API 1 → 1°C
+        # API 1 → 1°C
     },
 }
 
@@ -150,7 +138,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Fault Alarm",
         "icon": "mdi:alert-circle",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "Compressor": {
         "dp_id": 112,
@@ -158,7 +146,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Compressor",
         "icon": "mdi:engine",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "FouValve": {
         "dp_id": 113,
@@ -166,7 +154,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Four-Way Valve",
         "icon": "mdi:valve",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "Heat": {
         "dp_id": 114,
@@ -174,7 +162,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Auxiliary Electric Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "Fan": {
         "dp_id": 115,
@@ -182,7 +170,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Fan",
         "icon": "mdi:fan",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "Pumb": {
         "dp_id": 116,
@@ -190,7 +178,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Water Pump",
         "icon": "mdi:water-pump",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "ChassisHeat": {
         "dp_id": 117,
@@ -198,7 +186,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Chassis Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "CrankshaftHeat": {
         "dp_id": 118,
@@ -206,7 +194,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Crankshaft Heater",
         "icon": "mdi:heating-coil",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -219,7 +207,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -236,8 +224,7 @@ NUMBER_TYPES = {
         "min_value": 8.0,
         "max_value": 40.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value / 10"
+        "api_conversion": "value / 10",
     },
     "Temp_Offset": {
         "dp_id": 101,
@@ -248,8 +235,7 @@ NUMBER_TYPES = {
         "min_value": 1.0,
         "max_value": 15.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value / 10" 
+        "api_conversion": "value / 10",
     },
 }
 
@@ -266,8 +252,7 @@ SELECT_TYPES = {
             "hot": "Heating",
             "cold": "Cooling",
             "auto": "Auto",
-            "eco": "ECO"
+            "eco": "ECO",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/elrnos.py
+++ b/custom_components/tuya_heat_pump/models/elrnos.py
@@ -14,7 +14,6 @@ SENSOR_TYPES = {
         "icon": "mdi:water-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "compressor_strength": {
         "dp_id": 20,
@@ -24,7 +23,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_top": {
         "dp_id": 21,
@@ -34,7 +32,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_bottom": {
         "dp_id": 22,
@@ -44,7 +41,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp": {
         "dp_id": 23,
@@ -54,7 +50,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp": {
         "dp_id": 24,
@@ -64,7 +59,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp": {
         "dp_id": 25,
@@ -74,7 +68,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp": {
         "dp_id": 26,
@@ -84,9 +77,7 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
-    
     # Temperature Sensors - Fahrenheit
     "temp_current_f": {
         "dp_id": 35,
@@ -96,7 +87,6 @@ SENSOR_TYPES = {
         "icon": "mdi:water-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "bottom_temp_f": {
         "dp_id": 37,
@@ -106,7 +96,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "around_temp_f": {
         "dp_id": 38,
@@ -116,7 +105,6 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "venting_temp_f": {
         "dp_id": 39,
@@ -126,9 +114,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
-    
     # Device Info & Counters
     "countdown_left": {
         "dp_id": 14,
@@ -137,7 +123,6 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "effluent_temp_f": {
         "dp_id": 40,
@@ -146,7 +131,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:counter",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "coiler_temp_f": {
         "dp_id": 41,
@@ -155,9 +139,7 @@ SENSOR_TYPES = {
         "unit": "min",
         "icon": "mdi:timer",
         "state_class": "measurement",
-        "conversion": "value"
     },
-    
     # Electrical Sensors (with scale conversion)
     "cur_current": {
         "dp_id": 101,
@@ -167,7 +149,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 1000"  # scale: 3
+        "conversion": "value / 1000",  # scale: 3
     },
     "cur_voltage": {
         "dp_id": 102,
@@ -177,7 +159,7 @@ SENSOR_TYPES = {
         "icon": "mdi:lightning-bolt",
         "device_class": "voltage",
         "state_class": "measurement",
-        "conversion": "value / 10"  # scale: 1
+        "conversion": "value / 10",  # scale: 1
     },
     "cur_power": {
         "dp_id": 103,
@@ -187,7 +169,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "power",
         "state_class": "measurement",
-        "conversion": "value / 10"  # scale: 1
+        "conversion": "value / 10",  # scale: 1
     },
     "electric_total": {
         "dp_id": 104,
@@ -197,9 +179,8 @@ SENSOR_TYPES = {
         "icon": "mdi:chart-line",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"  # scale: 2
+        "conversion": "value / 100",  # scale: 2
     },
-    
     # Power Consumption (Today's Energy)
     "power_consumption": {
         "dp_id": 18,
@@ -209,7 +190,7 @@ SENSOR_TYPES = {
         "icon": "mdi:flash",
         "device_class": "energy",
         "state_class": "total_increasing",
-        "conversion": "value / 100"  # scale: 2
+        "conversion": "value / 100",  # scale: 2
     },
 }
 
@@ -224,106 +205,102 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Alarm",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
-    
     # Operation States
     "compressor_state": {
         "dp_id": 27,
         "code": "compressor_state",
         "name": "Compressor State",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "four_valve_state": {
         "dp_id": 28,
         "code": "four_valve_state",
         "name": "4-Way Valve State",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "draught_fan_state": {
         "dp_id": 29,
         "code": "draught_fan_state",
         "name": "Low Pressure Switch",
         "device_class": "safety",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "pump_state": {
         "dp_id": 30,
         "code": "pump_state",
         "name": "Refrigerant/Water Cycle",
         "icon": "mdi:water-pump",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "backwater": {
         "dp_id": 31,
         "code": "backwater",
         "name": "Pump State",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "ele_heating_state": {
         "dp_id": 32,
         "code": "ele_heating_state",
         "name": "Electric Heating State",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost_state": {
         "dp_id": 33,
         "code": "defrost_state",
         "name": "High Pressure Switch",
         "device_class": "safety",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "defrost": {
         "dp_id": 7,
         "code": "defrost",
         "name": "Defrosting",
         "device_class": "cold",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
-    
     # Electrical & Protection
     "lpress": {
         "dp_id": 105,
         "code": "lpress",
         "name": "Power Detection",
         "device_class": "power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "link": {
         "dp_id": 106,
         "code": "link",
         "name": "Linkage Switch",
         "device_class": "connectivity",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "flowswitch": {
         "dp_id": 107,
         "code": "flowswitch",
         "name": "Water Flow Switch",
         "device_class": "running",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
-    
     # DIP Switches
     "sw1": {
         "dp_id": 108,
         "code": "sw1",
         "name": "DIP Switch 1",
         "icon": "mdi:dip-switch",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "sw2": {
         "dp_id": 109,
         "code": "sw2",
         "name": "DIP Switch 2",
         "icon": "mdi:dip-switch",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
-    
     # Cooling Available
     "cancool": {
         "dp_id": 110,
@@ -331,7 +308,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Cooling Available",
         "device_class": "power",
         "icon": "mdi:snowflake",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -345,7 +322,7 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -363,8 +340,6 @@ NUMBER_TYPES = {
         "min_value": 15.0,
         "max_value": 75.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "temp_set_f": {
         "dp_id": 34,
@@ -375,8 +350,6 @@ NUMBER_TYPES = {
         "min_value": 59.0,
         "max_value": 167.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -395,9 +368,8 @@ SELECT_TYPES = {
             "ECO": "ECO Mode",
             "HYB": "Hybrid Mode",
             "HYB1": "Hybrid Mode 1",
-            "ELE": "Electric Mode"
+            "ELE": "Electric Mode",
         },
-        "conversion": "value"
     },
     "temp_unit_convert": {
         "dp_id": 6,
@@ -406,9 +378,8 @@ SELECT_TYPES = {
         "icon": "mdi:thermometer",
         "options": {
             "c": "Celsius",
-            "f": "Fahrenheit"
+            "f": "Fahrenheit",
         },
-        "conversion": "value"
     },
     "work_state": {
         "dp_id": 17,
@@ -418,9 +389,8 @@ SELECT_TYPES = {
         "options": {
             "normal": "Normal",
             "ERR": "Error",
-            "NO": "No Status"
+            "NO": "No Status",
         },
-        "conversion": "value"
     },
     "flow": {
         "dp_id": 19,
@@ -430,9 +400,8 @@ SELECT_TYPES = {
         "options": {
             "OFF": "Off",
             "LOW": "Low Speed",
-            "High": "High Speed"
+            "High": "High Speed",
         },
-        "conversion": "value"
     },
 }
 # ====================================================

--- a/custom_components/tuya_heat_pump/models/eu20ns.py
+++ b/custom_components/tuya_heat_pump/models/eu20ns.py
@@ -14,7 +14,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "temp_bottom": {
         "dp_id": 22,
@@ -24,7 +24,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-water",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "coiler_temp": {
         "dp_id": 23,
@@ -34,7 +34,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "venting_temp": {
         "dp_id": 24,
@@ -44,7 +44,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "effluent_temp": {
         "dp_id": 25,
@@ -54,7 +54,7 @@ SENSOR_TYPES = {
         "icon": "mdi:water-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_liquid": {
         "dp_id": 128,
@@ -64,7 +64,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-low",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_eva": {
         "dp_id": 140,
@@ -74,7 +74,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_con": {
         "dp_id": 141,
@@ -84,7 +84,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_room1": {
         "dp_id": 139,
@@ -94,7 +94,7 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_room2": {
         "dp_id": 145,
@@ -104,7 +104,7 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "t_ipm": {
         "dp_id": 138,
@@ -114,9 +114,7 @@ SENSOR_TYPES = {
         "icon": "mdi:chip",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
-    
     # Compressor & Performance
     "temp_current": {
         "dp_id": 16,
@@ -126,7 +124,6 @@ SENSOR_TYPES = {
         "icon": "mdi:sine-wave",
         "device_class": "frequency",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "compressor_strength": {
         "dp_id": 20,
@@ -136,7 +133,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "i_compressor": {
         "dp_id": 137,
@@ -146,7 +143,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "ic_drive_board": {
         "dp_id": 142,
@@ -156,7 +153,7 @@ SENSOR_TYPES = {
         "icon": "mdi:current-ac",
         "device_class": "current",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
     "times_comp": {
         "dp_id": 143,
@@ -165,7 +162,6 @@ SENSOR_TYPES = {
         "unit": "times",
         "icon": "mdi:counter",
         "state_class": "total_increasing",
-        "conversion": "value"
     },
     "times_defrosting": {
         "dp_id": 144,
@@ -174,9 +170,7 @@ SENSOR_TYPES = {
         "unit": "times",
         "icon": "mdi:snowflake",
         "state_class": "total_increasing",
-        "conversion": "value"
     },
-    
     # Fans & Valves
     "fan1_rpm": {
         "dp_id": 132,
@@ -185,7 +179,6 @@ SENSOR_TYPES = {
         "unit": "RPM",
         "icon": "mdi:fan",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "valve_step_1": {
         "dp_id": 134,
@@ -194,9 +187,7 @@ SENSOR_TYPES = {
         "unit": "steps",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value"
     },
-    
     # Water Flow
     "q_water": {
         "dp_id": 129,
@@ -205,9 +196,8 @@ SENSOR_TYPES = {
         "unit": "L/min",
         "icon": "mdi:water-pump",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
-    
     # Energy
     "power_consumption": {
         "dp_id": 18,
@@ -217,9 +207,8 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
-    
     # Error codes (as sensors)
     "temp_current_f": {
         "dp_id": 35,
@@ -228,7 +217,6 @@ SENSOR_TYPES = {
         "unit": "",
         "icon": "mdi:alert-circle",
         "device_class": "enum",
-        "conversion": "value",
         "options": {
             "0": "No Fault",
             "1": "Acceleration Overcurrent",
@@ -240,10 +228,9 @@ SENSOR_TYPES = {
             "8": "Step Out Fault",
             "9": "Phase Loss Fault",
             "10": "IPM Protection",
-            "19": "Current Detection Circuit"
-        }
+            "19": "Current Detection Circuit",
+        },
     },
-    
     # Temperature settings (read-only values)
     "p02_heating": {
         "dp_id": 117,
@@ -253,7 +240,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "p03_cooling": {
         "dp_id": 118,
@@ -263,7 +249,6 @@ SENSOR_TYPES = {
         "icon": "mdi:snowflake",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "p04_dhw": {
         "dp_id": 119,
@@ -273,7 +258,6 @@ SENSOR_TYPES = {
         "icon": "mdi:water-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "temp_": {
         "dp_id": 125,
@@ -283,7 +267,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "t_room1_setting": {
         "dp_id": 130,
@@ -293,7 +276,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat-box",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value"
     },
     "t_room2_setting": {
         "dp_id": 131,
@@ -303,7 +285,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat-box",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value / 10"
+        "conversion": "value / 10",
     },
 }
 
@@ -316,56 +298,56 @@ BINARY_SENSOR_TYPES = {
         "code": "fault",
         "name": "Fault Status (Group 1)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "smart_system": {
         "dp_id": 109,
         "code": "smart_system",
         "name": "Fault Status (Group 2)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "power_system": {
         "dp_id": 120,
         "code": "power_system",
         "name": "Fault Status (Group 3)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "ithium_battery_system": {
         "dp_id": 121,
         "code": "ithium_battery_system",
         "name": "Fault Status (Group 4)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "electronic_system": {
         "dp_id": 122,
         "code": "electronic_system",
         "name": "Fault Status (Group 5)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "bcu_com_state": {
         "dp_id": 123,
         "code": "bcu_com_state",
         "name": "Fault Status (Group 6)",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "state_way": {
         "dp_id": 135,
         "code": "state_way",
         "name": "4-Way Valve State",
         "device_class": "opening",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "cooling_heating": {
         "dp_id": 124,
         "code": "cooling_heating",
         "name": "AC Temperature Setting Mode",
         "device_class": "heat",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -378,14 +360,14 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "child_lock": {
         "dp_id": 3,
         "code": "child_lock",
         "name": "Night Mode",
         "icon": "mdi:weather-night",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -402,8 +384,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 23.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "water_set": {
         "dp_id": 10,
@@ -414,8 +394,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 23.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "p02_heating": {
         "dp_id": 117,
@@ -426,8 +404,6 @@ NUMBER_TYPES = {
         "min_value": 10.0,
         "max_value": 75.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "p03_cooling": {
         "dp_id": 118,
@@ -438,8 +414,6 @@ NUMBER_TYPES = {
         "min_value": 7.0,
         "max_value": 25.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "p04_dhw": {
         "dp_id": 119,
@@ -450,8 +424,6 @@ NUMBER_TYPES = {
         "min_value": 10.0,
         "max_value": 70.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "temp_": {
         "dp_id": 125,
@@ -462,8 +434,6 @@ NUMBER_TYPES = {
         "min_value": 7.0,
         "max_value": 75.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "t_room1_setting": {
         "dp_id": 130,
@@ -474,8 +444,6 @@ NUMBER_TYPES = {
         "min_value": 18.0,
         "max_value": 35.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "t_room2_setting": {
         "dp_id": 131,
@@ -487,7 +455,7 @@ NUMBER_TYPES = {
         "max_value": 35.0,
         "step": 1.0,
         "conversion": "value / 10",
-        "api_conversion": "value * 10"
+        "api_conversion": "value * 10",
     },
 }
 
@@ -505,9 +473,8 @@ SELECT_TYPES = {
             "Heating": "Heating Only",
             "Hot_Heating": "Hot Water + Heating",
             "Cooling": "Cooling Only",
-            "Hot_Cooling": "Hot Water + Cooling"
+            "Hot_Cooling": "Hot Water + Cooling",
         },
-        "conversion": "value"
     },
 }
 

--- a/custom_components/tuya_heat_pump/models/f6ry00.py
+++ b/custom_components/tuya_heat_pump/models/f6ry00.py
@@ -14,7 +14,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_top": {
         "dp_id": 110,
@@ -24,7 +23,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-up",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_bottom": {
         "dp_id": 111,
@@ -34,7 +32,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-chevron-down",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_coiler": {
         "dp_id": 112,
@@ -44,7 +41,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_venting": {
         "dp_id": 113,
@@ -54,7 +50,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer-alert",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_effluent": {
         "dp_id": 114,
@@ -74,7 +69,6 @@ SENSOR_TYPES = {
         "icon": "mdi:home-thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_inflow": {
         "dp_id": 117,
@@ -94,7 +88,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_coiler_inside": {
         "dp_id": 119,
@@ -104,7 +97,6 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "temp_radiator": {
         "dp_id": 120,
@@ -114,9 +106,7 @@ SENSOR_TYPES = {
         "icon": "mdi:thermometer",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
-    
     # ========== COMPRESSOR & VALVE ==========
     "compressor_strength": {
         "dp_id": 109,
@@ -125,7 +115,6 @@ SENSOR_TYPES = {
         "unit": "%",
         "icon": "mdi:engine",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "expansion_valve": {
         "dp_id": 121,
@@ -134,9 +123,7 @@ SENSOR_TYPES = {
         "unit": "P",
         "icon": "mdi:pipe-valve",
         "state_class": "measurement",
-        "conversion": "value",
     },
-    
     # ========== POWER & ENERGY ==========
     "power": {
         "dp_id": 125,
@@ -148,7 +135,6 @@ SENSOR_TYPES = {
         "state_class": "measurement",
         "conversion": "value / 1000",  # scale: 3
     },
-    
     # ========== READ-ONLY SETPOINTS ==========
     "temp_set1": {
         "dp_id": 104,
@@ -158,43 +144,38 @@ SENSOR_TYPES = {
         "icon": "mdi:thermostat",
         "device_class": "temperature",
         "state_class": "measurement",
-        "conversion": "value",
     },
-    
     # ========== STATUS SENSORS ==========
     "power_w": {
         "dp_id": 122,
         "code": "power_w",
         "name": "Power Display",
         "icon": "mdi:eye",
-        "conversion": "value",
         "options": {
             0: "Not Display",
-            1: "Display"
-        }
+            1: "Display",
+        },
     },
     "cool_enable": {
         "dp_id": 123,
         "code": "cool_enable",
         "name": "Cooling Mode",
         "icon": "mdi:snowflake",
-        "conversion": "value",
         "options": {
             0: "Single Temperature Mode",
-            1: "Dual Temperature Mode"
-        }
+            1: "Dual Temperature Mode",
+        },
     },
     "oc_mode": {
         "dp_id": 124,
         "code": "oc_mode",
         "name": "Overclock Mode",
         "icon": "mdi:speedometer",
-        "conversion": "value",
         "options": {
             "oc_0": "No Overclock",
             "oc_1": "Overclock Mode 1",
-            "oc_2": "Overclock Mode 2"
-        }
+            "oc_2": "Overclock Mode 2",
+        },
     },
 }
 
@@ -207,14 +188,14 @@ BINARY_SENSOR_TYPES = {
         "code": "fault1",
         "name": "Fault Code 1",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
     "fault2": {
         "dp_id": 116,
         "code": "fault2",
         "name": "Fault Code 2",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
 }
 
@@ -227,14 +208,14 @@ SWITCH_TYPES = {
         "code": "switch1",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "child_lock1": {
         "dp_id": 103,
         "code": "child_lock1",
         "name": "Child Lock",
         "icon": "mdi:lock",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -251,8 +232,6 @@ NUMBER_TYPES = {
         "min_value": -22.0,
         "max_value": 104.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -268,9 +247,8 @@ SELECT_TYPES = {
         "options": {
             "auto": "Auto",
             "heating": "Heating",
-            "cold": "Cooling"
+            "cold": "Cooling",
         },
-        "conversion": "value"
     },
     "work_mode": {
         "dp_id": 105,
@@ -281,9 +259,8 @@ SELECT_TYPES = {
             "power": "Power",
             "boost": "Boost",
             "silence": "Silence",
-            "perfect": "Perfect"
+            "perfect": "Perfect",
         },
-        "conversion": "value"
     },
     "temp_unit_convert1": {
         "dp_id": 106,
@@ -292,8 +269,7 @@ SELECT_TYPES = {
         "icon": "mdi:thermometer",
         "options": {
             "c": "Celsius",
-            "f": "Fahrenheit"
+            "f": "Fahrenheit",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/models/fc1fls.py
+++ b/custom_components/tuya_heat_pump/models/fc1fls.py
@@ -13,14 +13,12 @@ SENSOR_TYPES = {
         "icon": "mdi:alert-circle",
         "device_class": "problem",
         "state_class": "measurement",
-        "conversion": "value",
     },
     "products_id": {
         "dp_id": 180,
         "code": "products_id",
         "name": "Product ID",
         "icon": "mdi:identifier",
-        "conversion": "value",
     },
 }
 
@@ -34,7 +32,7 @@ BINARY_SENSOR_TYPES = {
         "name": "Fault Alarm",
         "icon": "mdi:alert-circle",
         "device_class": "problem",
-        "conversion": "value != 0"
+        "conversion": "value != 0",
     },
 }
 
@@ -47,14 +45,14 @@ SWITCH_TYPES = {
         "code": "switch",
         "name": "Power",
         "icon": "mdi:power",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
     "reset": {
         "dp_id": 125,
         "code": "reset",
         "name": "Reset to Default",
         "icon": "mdi:restore",
-        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']"
+        "conversion": "value in [1, True, '1', 'true', 'on', 'yes', 'enable', 'open']",
     },
 }
 
@@ -71,8 +69,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 99.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "heating_setting": {
         "dp_id": 111,
@@ -83,8 +79,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 99.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "cooling_setting": {
         "dp_id": 112,
@@ -95,8 +89,6 @@ NUMBER_TYPES = {
         "min_value": 0.0,
         "max_value": 99.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
     "hdef": {
         "dp_id": 130,
@@ -107,8 +99,6 @@ NUMBER_TYPES = {
         "min_value": 1.0,
         "max_value": 8.0,
         "step": 1.0,
-        "conversion": "value",
-        "api_conversion": "value"
     },
 }
 
@@ -124,9 +114,8 @@ SELECT_TYPES = {
         "options": {
             "smart": "Smart",
             "strong": "Strong",
-            "mute": "Mute"
+            "mute": "Mute",
         },
-        "conversion": "value"
     },
     "work_mode": {
         "dp_id": 5,
@@ -138,9 +127,8 @@ SELECT_TYPES = {
             "heat": "Heating",
             "cool": "Cooling",
             "wth_heat": "Hot Water + Heating",
-            "wth_cool": "Hot Water + Cooling"
+            "wth_cool": "Hot Water + Cooling",
         },
-        "conversion": "value"
     },
     "temp_unit_convert": {
         "dp_id": 6,
@@ -149,8 +137,7 @@ SELECT_TYPES = {
         "icon": "mdi:thermometer",
         "options": {
             "c": "Celsius",
-            "f": "Fahrenheit"
+            "f": "Fahrenheit",
         },
-        "conversion": "value"
     },
 }

--- a/custom_components/tuya_heat_pump/number.py
+++ b/custom_components/tuya_heat_pump/number.py
@@ -1,18 +1,22 @@
 """Number platform for Tuya Heatpump."""
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
 from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .conversion import Conversion
 from .coordinator import TuyaScaleDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -20,24 +24,24 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Tuya Heatpump numbers from a config entry."""
-    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
     numbers = []
-    
+
     # Model mapping'den number'ları al
     number_configs = coordinator.model_mapping.get("numbers", {})
-    
+
     # 🔴 DEĞİŞİKLİK: coordinator.data kontrolü kaldırıldı
     for number_code, number_config in number_configs.items():
-        numbers.append(
-            TuyaHeatpumpNumber(coordinator, number_code, number_config)
-        )
+        numbers.append(TuyaHeatpumpNumber(coordinator, number_code, number_config))
         _LOGGER.info(
             "Adding number: %s (%s)",
-            number_config.get('name', number_code),
-            number_code
+            number_config.get("name", number_code),
+            number_code,
         )
-    
+
     async_add_entities(numbers)
 
 
@@ -48,26 +52,28 @@ class TuyaHeatpumpNumber(NumberEntity):
         self,
         coordinator: TuyaScaleDataUpdateCoordinator,
         number_code: str,
-        config: dict
+        config: dict,
     ) -> None:
         """Initialize the number."""
         self.coordinator = coordinator
         self._number_code = number_code
         self._config = config
-        
+
         # Device name ile unique_id oluştur
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_{number_code}"
-        
-        self._attr_name = config.get('name', number_code)
-        self._attr_icon = config.get('icon')
-        self._attr_native_unit_of_measurement = config.get('unit')
-        self._attr_native_min_value = config.get('min_value', 0.0)
-        self._attr_native_max_value = config.get('max_value', 100.0)
-        self._attr_native_step = config.get('step', 1.0)
+
+        self._attr_name = config.get("name", number_code)
+        self._attr_icon = config.get("icon")
+        self._attr_native_unit_of_measurement = config.get("unit")
+        self._attr_native_min_value = config.get("min_value", 0.0)
+        self._attr_native_max_value = config.get("max_value", 100.0)
+        self._attr_native_step = config.get("step", 1.0)
         self._attr_has_entity_name = True
         self._attr_mode = NumberMode.BOX
-        
+
         # Device info
         self._attr_device_info = coordinator.device_info
 
@@ -81,13 +87,12 @@ class TuyaHeatpumpNumber(NumberEntity):
         """Return the current value."""
         if not self.coordinator.data or self._number_code not in self.coordinator.data:
             return None
-            
-        raw_value = self.coordinator.data[self._number_code]['value']
-        
-        # Conversion uygula
-        conversion = self._config.get('conversion', 'value')
+
+        raw_value = self.coordinator.data[self._number_code]["value"]
+
+        conversion = Conversion(self._config.get("conversion", "value"))
         try:
-            result = eval(conversion, {"value": raw_value, "__builtins__": {}})
+            result = conversion.convert(raw_value)
             return float(result) if isinstance(result, (int, float)) else result
         except Exception as err:
             _LOGGER.warning("Conversion failed for %s: %s", self._number_code, err)
@@ -95,26 +100,29 @@ class TuyaHeatpumpNumber(NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         """Set new value."""
-        _LOGGER.info("Attempting to set %s to %s %s", 
-                    self._number_code, value, self._attr_native_unit_of_measurement)
-        
-        # API conversion varsa uygula (HA value → API value)
-        api_value = value
-        if 'api_conversion' in self._config:
-            try:
-                api_value = eval(self._config['api_conversion'], {"value": value, "__builtins__": {}})
-                _LOGGER.debug("Converted HA value %s → API value %s", value, api_value)
-            except Exception as err:
-                _LOGGER.warning("API conversion failed: %s", err)
-        
+        _LOGGER.info(
+            "Attempting to set %s to %s %s",
+            self._number_code,
+            value,
+            self._attr_native_unit_of_measurement,
+        )
+
+        conversion = Conversion(self._config.get("api_conversion", "value"))
+        try:
+            api_value = conversion.convert(value)
+            _LOGGER.debug("Converted HA value %s → API value %s", value, api_value)
+        except Exception as err:
+            api_value = value
+            _LOGGER.warning("API conversion failed: %s", err)
+
         success = await self.coordinator.send_command(self._number_code, api_value)
-        
+
         if success:
             _LOGGER.info("✅ Successfully set %s to %s", self._number_code, value)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.warning("❌ Failed to set %s to %s", self._number_code, value)
-            
+
             raise HomeAssistantError(
                 f"{self._config.get('name', self._number_code)} değeri değiştirilemiyor. "
                 f"Cihazınız bu ayarı değiştirmeye izin vermiyor. "
@@ -125,9 +133,9 @@ class TuyaHeatpumpNumber(NumberEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return (
-            self.coordinator.last_update_success and 
-            self.coordinator.data is not None and
-            self._number_code in self.coordinator.data
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self._number_code in self.coordinator.data
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/tuya_heat_pump/select.py
+++ b/custom_components/tuya_heat_pump/select.py
@@ -1,18 +1,22 @@
 """Select platform for Tuya Heatpump."""
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
 from homeassistant.components.select import SelectEntity
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .conversion import Conversion
 from .coordinator import TuyaScaleDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -20,24 +24,24 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Tuya Heatpump selects from a config entry."""
-    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
     selects = []
-    
+
     # Model mapping'den select'leri al
     select_configs = coordinator.model_mapping.get("selects", {})
-    
+
     # 🔴 DEĞİŞİKLİK: coordinator.data kontrolü kaldırıldı
     for select_code, select_config in select_configs.items():
-        selects.append(
-            TuyaHeatpumpSelect(coordinator, select_code, select_config)
-        )
+        selects.append(TuyaHeatpumpSelect(coordinator, select_code, select_config))
         _LOGGER.info(
             "Adding select: %s (%s)",
-            select_config.get('name', select_code),
-            select_code
+            select_config.get("name", select_code),
+            select_code,
         )
-    
+
     async_add_entities(selects)
 
 
@@ -50,27 +54,29 @@ class TuyaHeatpumpSelect(SelectEntity):
         self,
         coordinator: TuyaScaleDataUpdateCoordinator,
         select_code: str,
-        config: dict
+        config: dict,
     ) -> None:
         """Initialize the select."""
         self.coordinator = coordinator
         self._select_code = select_code
         self._config = config
-        
+
         # Device name ile unique_id oluştur
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_{select_code}"
-        
+
         # Translation key varsa kullan
-        if 'translation_key' in config:
-            self._attr_translation_key = config['translation_key']
+        if "translation_key" in config:
+            self._attr_translation_key = config["translation_key"]
         else:
-            self._attr_name = config.get('name', select_code)
-        
-        self._attr_icon = config.get('icon')
-        
+            self._attr_name = config.get("name", select_code)
+
+        self._attr_icon = config.get("icon")
+
         # Options'ları config'den al
-        options_dict = config.get('options', {})
+        options_dict = config.get("options", {})
         # options dict ise value:label şeklinde, liste ise direkt
         if isinstance(options_dict, dict):
             self._attr_options = list(options_dict.keys())
@@ -78,7 +84,7 @@ class TuyaHeatpumpSelect(SelectEntity):
         else:
             self._attr_options = options_dict
             self._option_labels = {opt: opt for opt in options_dict}
-        
+
         # Device info
         self._attr_device_info = coordinator.device_info
 
@@ -92,21 +98,23 @@ class TuyaHeatpumpSelect(SelectEntity):
         """Return the current selected option."""
         if not self.coordinator.data or self._select_code not in self.coordinator.data:
             return None
-            
-        value = self.coordinator.data[self._select_code]['value']
-        
+
+        raw_value = self.coordinator.data[self._select_code]["value"]
+
         # Conversion varsa uygula
-        conversion = self._config.get('conversion', 'value')
-        if conversion != 'value':
-            try:
-                value = eval(conversion, {"value": value, "__builtins__": {}})
-            except Exception as err:
-                _LOGGER.warning("Conversion failed for %s: %s", self._select_code, err)
-        
+        conversion = Conversion(self._config.get("conversion", "value"))
+        try:
+            value = conversion.convert(raw_value)
+        except Exception as err:
+            value = raw_value
+            _LOGGER.warning("Conversion failed for %s: %s", self._select_code, err)
+
         if isinstance(value, str):
             return value
-        
-        _LOGGER.warning("Unexpected value type for %s: %s", self._select_code, type(value))
+
+        _LOGGER.warning(
+            "Unexpected value type for %s: %s", self._select_code, type(value)
+        )
         return None
 
     @property
@@ -117,24 +125,23 @@ class TuyaHeatpumpSelect(SelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
         _LOGGER.info("Changing %s to %s", self._select_code, option)
-        
-        # API conversion varsa uygula
-        api_value = option
-        if 'api_conversion' in self._config:
-            try:
-                api_value = eval(self._config['api_conversion'], {"value": option, "__builtins__": {}})
-                _LOGGER.debug("Converted HA option %s → API value %s", option, api_value)
-            except Exception as err:
-                _LOGGER.warning("API conversion failed: %s", err)
-        
+
+        conversion = Conversion(self._config.get("api_conversion", "value"))
+        try:
+            api_value = conversion.convert(option)
+            _LOGGER.debug("Converted HA option %s → API value %s", option, api_value)
+        except Exception as err:
+            api_value = option
+            _LOGGER.warning("API conversion failed: %s", err)
+
         success = await self.coordinator.send_command(self._select_code, api_value)
-        
+
         if success:
             _LOGGER.info("✅ Successfully changed %s to %s", self._select_code, option)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.warning("❌ Failed to change %s to %s", self._select_code, option)
-            
+
             raise HomeAssistantError(
                 f"{self._config.get('name', self._select_code)} değiştirilemiyor. "
                 f"Cihazınız bu modu değiştirmeye izin vermiyor. "
@@ -145,9 +152,9 @@ class TuyaHeatpumpSelect(SelectEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return (
-            self.coordinator.last_update_success and 
-            self.coordinator.data is not None and
-            self._select_code in self.coordinator.data
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self._select_code in self.coordinator.data
         )
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/tuya_heat_pump/sensor.py
+++ b/custom_components/tuya_heat_pump/sensor.py
@@ -1,17 +1,22 @@
 """Sensor platform for Tuya Heatpump."""
+
 from __future__ import annotations
+
 import logging
-from homeassistant.core import HomeAssistant
+
 from homeassistant.components.sensor import SensorEntity
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
+from .conversion import Conversion
 from .coordinator import TuyaScaleDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -19,30 +24,41 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Tuya Heatpump sensors from a config entry."""
-    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
     sensors = []
-    
+
     # Model mapping'den sensörleri al
     sensor_configs = coordinator.model_mapping.get("sensors", {})
-    
+
     for sensor_code, sensor_config in sensor_configs.items():
         # API'de bu code var mı kontrol et
         if coordinator.data and sensor_code in coordinator.data:
             sensors.append(TuyaHeatpumpSensor(coordinator, sensor_code, sensor_config))
-            _LOGGER.info("Adding sensor: %s (%s)", sensor_config.get('name', sensor_code), sensor_code)
+            _LOGGER.info(
+                "Adding sensor: %s (%s)",
+                sensor_config.get("name", sensor_code),
+                sensor_code,
+            )
         elif sensor_code == "calculated_power":
             # calculated_power her zaman eklenir (API'de yok, hesaplanır)
             sensors.append(TuyaHeatpumpSensor(coordinator, sensor_code, sensor_config))
-            _LOGGER.info("Adding calculated sensor: %s", sensor_config.get('name', sensor_code))
+            _LOGGER.info(
+                "Adding calculated sensor: %s", sensor_config.get("name", sensor_code)
+            )
         elif sensor_code == "total_energy":
             # total_energy her zaman eklenir
             sensors.append(TuyaEnergySensor(coordinator, sensor_config))
-            _LOGGER.info("Adding energy sensor: %s", sensor_config.get('name', sensor_code))
+            _LOGGER.info(
+                "Adding energy sensor: %s", sensor_config.get("name", sensor_code)
+            )
         else:
             _LOGGER.debug("Sensor %s not found in device data, skipping", sensor_code)
-    
+
     async_add_entities(sensors)
+
 
 class TuyaHeatpumpSensor(SensorEntity):
     """Representation of a Tuya Heatpump Sensor."""
@@ -51,21 +67,23 @@ class TuyaHeatpumpSensor(SensorEntity):
         self,
         coordinator: TuyaScaleDataUpdateCoordinator,
         sensor_code: str,
-        config: dict
+        config: dict,
     ) -> None:
         """Initialize the sensor."""
         self.coordinator = coordinator
         self._sensor_code = sensor_code
         self._config = config
-        
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_{sensor_code}"
-        
-        self._attr_name = config.get('name', sensor_code)
-        self._attr_native_unit_of_measurement = config.get('unit')
-        self._attr_icon = config.get('icon')
-        self._attr_device_class = config.get('device_class')
-        self._attr_state_class = config.get('state_class')
+
+        self._attr_name = config.get("name", sensor_code)
+        self._attr_native_unit_of_measurement = config.get("unit")
+        self._attr_icon = config.get("icon")
+        self._attr_device_class = config.get("device_class")
+        self._attr_state_class = config.get("state_class")
         self._attr_has_entity_name = True
         self._attr_device_info = coordinator.device_info
 
@@ -79,17 +97,15 @@ class TuyaHeatpumpSensor(SensorEntity):
         """Return the state of the sensor."""
         if self._sensor_code == "calculated_power":
             return self._calculate_power()
-            
+
         if not self.coordinator.data or self._sensor_code not in self.coordinator.data:
             return None
-            
-        raw_value = self.coordinator.data[self._sensor_code]['value']
-        
-        # Conversion uygula
-        conversion = self._config.get('conversion', 'value')
+
+        raw_value = self.coordinator.data[self._sensor_code]["value"]
+
+        conversion = Conversion(self._config.get("conversion", "value"))
         try:
-            # Güvenli eval
-            result = eval(conversion, {"value": raw_value, "__builtins__": {}})
+            result = conversion.convert(raw_value)
             return float(result) if isinstance(result, (int, float)) else result
         except Exception as err:
             _LOGGER.warning("Conversion failed for %s: %s", self._sensor_code, err)
@@ -99,35 +115,35 @@ class TuyaHeatpumpSensor(SensorEntity):
         """Güç hesaplama: P = V × I"""
         if not self.coordinator.data:
             return None
-            
+
         voltage = None
         current = None
-        
+
         # Model mapping'den ac_vol ve ac_curr config'lerini bul
         sensor_configs = self.coordinator.model_mapping.get("sensors", {})
-        
-        if 'ac_vol' in sensor_configs and 'ac_vol' in self.coordinator.data:
-            config = sensor_configs['ac_vol']
-            raw_voltage = self.coordinator.data['ac_vol']['value']
-            conversion = config.get('conversion', 'value')
+
+        if "ac_vol" in sensor_configs and "ac_vol" in self.coordinator.data:
+            config = sensor_configs["ac_vol"]
+            raw_voltage = self.coordinator.data["ac_vol"]["value"]
+            conversion = Conversion(config.get("conversion", "value"))
             try:
-                voltage = eval(conversion, {"value": raw_voltage, "__builtins__": {}})
-            except:
+                voltage = conversion.convert(raw_voltage)
+            except Exception:
                 voltage = raw_voltage
-        
-        if 'ac_curr' in sensor_configs and 'ac_curr' in self.coordinator.data:
-            config = sensor_configs['ac_curr']
-            raw_current = self.coordinator.data['ac_curr']['value']
-            conversion = config.get('conversion', 'value')
+
+        if "ac_curr" in sensor_configs and "ac_curr" in self.coordinator.data:
+            config = sensor_configs["ac_curr"]
+            raw_current = self.coordinator.data["ac_curr"]["value"]
+            conversion = Conversion(config.get("conversion", "value"))
             try:
-                current = eval(conversion, {"value": raw_current, "__builtins__": {}})
-            except:
+                current = conversion.convert(raw_current)
+            except Exception:
                 current = raw_current
-        
+
         if voltage is not None and current is not None:
             power = voltage * current
             return round(power, 2)
-            
+
         return None
 
     @property
@@ -135,11 +151,11 @@ class TuyaHeatpumpSensor(SensorEntity):
         """Return if entity is available."""
         if self._sensor_code in ["calculated_power", "total_energy"]:
             return self.coordinator.last_update_success
-            
+
         return (
-            self.coordinator.last_update_success and 
-            self.coordinator.data is not None and
-            self._sensor_code in self.coordinator.data
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self._sensor_code in self.coordinator.data
         )
 
     async def async_added_to_hass(self) -> None:
@@ -152,30 +168,34 @@ class TuyaHeatpumpSensor(SensorEntity):
 
 class TuyaEnergySensor(SensorEntity, RestoreEntity):
     """Total Energy Sensor for Tuya Heatpump."""
-    
+
     _attr_device_class = "energy"
     _attr_state_class = "total_increasing"
     _attr_has_entity_name = True
 
-    def __init__(self, coordinator: TuyaScaleDataUpdateCoordinator, config: dict) -> None:
+    def __init__(
+        self, coordinator: TuyaScaleDataUpdateCoordinator, config: dict
+    ) -> None:
         """Initialize energy sensor."""
         self.coordinator = coordinator
         self._config = config
         self._total_energy = 0.0
         self._last_update = None
         self._last_power = 0.0
-        
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_total_energy"
-        self._attr_name = config.get('name', 'AC Total Energy')
-        self._attr_native_unit_of_measurement = config.get('unit', 'Wh')
-        self._attr_icon = config.get('icon', 'mdi:lightning-bolt')
+        self._attr_name = config.get("name", "AC Total Energy")
+        self._attr_native_unit_of_measurement = config.get("unit", "Wh")
+        self._attr_icon = config.get("icon", "mdi:lightning-bolt")
         self._attr_device_info = coordinator.device_info
 
     async def async_added_to_hass(self) -> None:
         """When entity is added to hass."""
         await super().async_added_to_hass()
-        
+
         # Restore state
         if (last_state := await self.async_get_last_state()) is not None:
             try:
@@ -183,11 +203,11 @@ class TuyaEnergySensor(SensorEntity, RestoreEntity):
                 _LOGGER.info("Energy sensor state restored: %s Wh", self._total_energy)
             except (ValueError, TypeError):
                 self._total_energy = 0.0
-        
+
         # Set initial values
         self._last_power = self._get_current_power() or 0.0
         self._last_update = dt_util.utcnow()
-        
+
         # Listen for updates
         self.async_on_remove(
             self.coordinator.async_add_listener(self._handle_coordinator_update)
@@ -197,58 +217,64 @@ class TuyaEnergySensor(SensorEntity, RestoreEntity):
         """Handle coordinator update."""
         current_power = self._get_current_power() or 0.0
         current_time = dt_util.utcnow()
-        
+
         # Calculate energy
         if self._last_update is not None:
-            time_diff = (current_time - self._last_update).total_seconds() / 3600.0  # hours
-            
+            time_diff = (
+                current_time - self._last_update
+            ).total_seconds() / 3600.0  # hours
+
             if time_diff > 0 and self._last_power > 0:
                 energy_increment = self._last_power * time_diff  # Wh
                 self._total_energy += energy_increment
-                _LOGGER.debug("Energy added: %.6f Wh, Total: %.3f Wh", energy_increment, self._total_energy)
-        
+                _LOGGER.debug(
+                    "Energy added: %.6f Wh, Total: %.3f Wh",
+                    energy_increment,
+                    self._total_energy,
+                )
+
         # Update values
         self._last_power = current_power
         self._last_update = current_time
-        
+
         self.async_write_ha_state()
 
     def _get_current_power(self) -> float | None:
         """Get current power in watts."""
         if not self.coordinator.data:
             return None
-            
+
         voltage = None
         current = None
-        
+
         # Model mapping'den config'leri kullan
         sensor_configs = self.coordinator.model_mapping.get("sensors", {})
-        
-        if 'ac_vol' in sensor_configs and 'ac_vol' in self.coordinator.data:
-            config = sensor_configs['ac_vol']
-            raw_voltage = self.coordinator.data['ac_vol']['value']
-            conversion = config.get('conversion', 'value')
+
+        if "ac_vol" in sensor_configs and "ac_vol" in self.coordinator.data:
+            config = sensor_configs["ac_vol"]
+            raw_voltage = self.coordinator.data["ac_vol"]["value"]
+            conversion = Conversion(config.get("conversion", "value"))
             try:
-                voltage = eval(conversion, {"value": raw_voltage, "__builtins__": {}})
+                voltage = conversion.convert(raw_voltage)
                 if isinstance(voltage, (int, float)) and voltage > 0:
                     voltage = float(voltage)
-            except:
+            except Exception:
                 voltage = None
-        
-        if 'ac_curr' in sensor_configs and 'ac_curr' in self.coordinator.data:
-            config = sensor_configs['ac_curr']
-            raw_current = self.coordinator.data['ac_curr']['value']
-            conversion = config.get('conversion', 'value')
+
+        if "ac_curr" in sensor_configs and "ac_curr" in self.coordinator.data:
+            config = sensor_configs["ac_curr"]
+            raw_current = self.coordinator.data["ac_curr"]["value"]
+            conversion = Conversion(config.get("conversion", "value"))
             try:
-                current = eval(conversion, {"value": raw_current, "__builtins__": {}})
+                current = conversion.convert(raw_current)
                 if isinstance(current, (int, float)) and current > 0:
                     current = float(current)
-            except:
+            except Exception:
                 current = None
-        
+
         if voltage is not None and current is not None:
             return voltage * current
-        
+
         return None
 
     @property

--- a/custom_components/tuya_heat_pump/switch.py
+++ b/custom_components/tuya_heat_pump/switch.py
@@ -1,18 +1,22 @@
 """Switch platform for Tuya Heatpump."""
+
 from __future__ import annotations
+
 import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchEntity
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
+from .conversion import Conversion
 from .coordinator import TuyaScaleDataUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -20,24 +24,24 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up Tuya Heatpump switches from a config entry."""
-    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][config_entry.entry_id]
-    
+    coordinator: TuyaScaleDataUpdateCoordinator = hass.data[DOMAIN][
+        config_entry.entry_id
+    ]
+
     switches = []
-    
+
     # Model mapping'den switch'leri al
     switch_configs = coordinator.model_mapping.get("switches", {})
-    
+
     # 🔴 DEĞİŞİKLİK: coordinator.data kontrolü kaldırıldı
     for switch_code, switch_config in switch_configs.items():
-        switches.append(
-            TuyaHeatpumpSwitch(coordinator, switch_code, switch_config)
-        )
+        switches.append(TuyaHeatpumpSwitch(coordinator, switch_code, switch_config))
         _LOGGER.info(
             "Adding switch: %s (%s)",
-            switch_config.get('name', switch_code),
-            switch_code
+            switch_config.get("name", switch_code),
+            switch_code,
         )
-    
+
     async_add_entities(switches)
 
 
@@ -48,21 +52,23 @@ class TuyaHeatpumpSwitch(SwitchEntity):
         self,
         coordinator: TuyaScaleDataUpdateCoordinator,
         switch_code: str,
-        config: dict
+        config: dict,
     ) -> None:
         """Initialize the switch."""
         self.coordinator = coordinator
         self._switch_code = switch_code
         self._config = config
-        
+
         # Device name ile unique_id oluştur
-        device_name_slug = coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        device_name_slug = (
+            coordinator.device_name.lower().replace(" ", "_").replace("-", "_")
+        )
         self._attr_unique_id = f"{device_name_slug}_{switch_code}"
-        
-        self._attr_name = config.get('name', switch_code)
-        self._attr_icon = config.get('icon')
+
+        self._attr_name = config.get("name", switch_code)
+        self._attr_icon = config.get("icon")
         self._attr_has_entity_name = True
-        
+
         # Device info
         self._attr_device_info = coordinator.device_info
 
@@ -76,48 +82,46 @@ class TuyaHeatpumpSwitch(SwitchEntity):
         """Return true if switch is on."""
         if not self.coordinator.data or self._switch_code not in self.coordinator.data:
             return None
-            
-        raw_value = self.coordinator.data[self._switch_code]['value']
-        
-        # Conversion uygula
-        conversion = self._config.get('conversion', 'bool(value)')
+
+        raw_value = self.coordinator.data[self._switch_code]["value"]
+
+        conversion = Conversion(self._config.get("conversion", "bool(value)"))
         try:
-            result = eval(conversion, {"value": raw_value, "__builtins__": {}})
+            result = conversion.convert(raw_value)
             return bool(result)
         except Exception as err:
             _LOGGER.warning("Conversion failed for %s: %s", self._switch_code, err)
-            
+
             # Fallback conversion
             if isinstance(raw_value, bool):
                 return raw_value
             elif isinstance(raw_value, (int, float)):
                 return bool(raw_value)
             elif isinstance(raw_value, str):
-                return raw_value.lower() in ['true', '1', 'on', 'yes', 'enable', 'open']
-            
+                return raw_value.lower() in ["true", "1", "on", "yes", "enable", "open"]
+
             return False
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the switch on."""
         _LOGGER.info("Turning ON %s", self._switch_code)
-        
-        # API conversion varsa uygula
-        api_value = True
-        if 'api_conversion' in self._config:
-            try:
-                api_value = eval(self._config['api_conversion'], {"value": True, "__builtins__": {}})
-                _LOGGER.debug("Converted ON → API value %s", api_value)
-            except Exception as err:
-                _LOGGER.warning("API conversion failed: %s", err)
-        
+
+        conversion = Conversion(self._config.get("api_conversion", "value"))
+        try:
+            api_value = conversion.convert(True)
+            _LOGGER.debug("Converted ON → API value %s", api_value)
+        except Exception as err:
+            api_value = True
+            _LOGGER.warning("API conversion failed: %s", err)
+
         success = await self.coordinator.send_command(self._switch_code, api_value)
-        
+
         if success:
             _LOGGER.info("✅ Successfully turned ON %s", self._switch_code)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.warning("❌ Failed to turn ON %s", self._switch_code)
-            
+
             raise HomeAssistantError(
                 f"{self._config.get('name', self._switch_code)} açılamıyor. "
                 f"Cihazınız bu özelliği değiştirmeye izin vermiyor. "
@@ -127,24 +131,23 @@ class TuyaHeatpumpSwitch(SwitchEntity):
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn the switch off."""
         _LOGGER.info("Turning OFF %s", self._switch_code)
-        
-        # API conversion varsa uygula
-        api_value = False
-        if 'api_conversion' in self._config:
-            try:
-                api_value = eval(self._config['api_conversion'], {"value": False, "__builtins__": {}})
-                _LOGGER.debug("Converted OFF → API value %s", api_value)
-            except Exception as err:
-                _LOGGER.warning("API conversion failed: %s", err)
-        
+
+        conversion = Conversion(self._config.get("api_conversion", "value"))
+        try:
+            api_value = conversion.convert(False)
+            _LOGGER.debug("Converted OFF → API value %s", api_value)
+        except Exception as err:
+            api_value = False
+            _LOGGER.warning("API conversion failed: %s", err)
+
         success = await self.coordinator.send_command(self._switch_code, api_value)
-        
+
         if success:
             _LOGGER.info("✅ Successfully turned OFF %s", self._switch_code)
             await self.coordinator.async_request_refresh()
         else:
             _LOGGER.warning("❌ Failed to turn OFF %s", self._switch_code)
-            
+
             raise HomeAssistantError(
                 f"{self._config.get('name', self._switch_code)} kapatılamıyor. "
                 f"Cihazınız bu özelliği değiştirmeye izin vermiyor. "
@@ -155,9 +158,9 @@ class TuyaHeatpumpSwitch(SwitchEntity):
     def available(self) -> bool:
         """Return if entity is available."""
         return (
-            self.coordinator.last_update_success and 
-            self.coordinator.data is not None and
-            self._switch_code in self.coordinator.data
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self._switch_code in self.coordinator.data
         )
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
Move `eval` calls into a shared `Conversion` class, and remove default conversions from model definitions.
