### PR TITLE
Add Tuya end-user API and AMT-Pool Mini support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 > [tuya_api_test.py](https://github.com/Korkuttum/tuya_heat_pump/blob/main/test/tuya_api_test.py)
 ### Supported Brands
 📋 **[Detailed list](https://github.com/Korkuttum/tuya_heat_pump/blob/main/supported_models.md)**
+- AMT-Pool Mini
 - Arçelik (Beko, Grundig)
 - ACIQ
 - Adlar Castra
@@ -51,11 +52,20 @@
 - Wopoltop
 ---
 
-This project allows you to control and monitor your Tuya heat pump device through Home Assistant — supports both Cloud and Local (push) connection modes.
+This project allows you to control and monitor your Tuya heat pump device
+through Home Assistant. It supports the Tuya End-user API, the legacy Tuya IoT
+Cloud API, and local LAN connections.
 
 ---
 
 ## Prerequisites
+
+### Tuya End-user API (recommended)
+
+1. Obtain an `sk-...` API key from [tuya.ai](https://tuya.ai/).
+2. Select **Cloud End-user API** during integration setup.
+3. Enter the API key and Device ID. The data center is detected from the
+   API-key prefix automatically.
 
 ### Enabling Tuya IoT Cloud Service
 
@@ -105,11 +115,14 @@ After installation, restart Home Assistant and follow these steps:
 1. Go to “Settings > Devices & Services”.
 2. Click “Add Integration”.
 3. Search for and select “Tuya Heat Pump”.
-4. For Cloud mode: enter your Tuya IoT Platform credentials:
+4. For Cloud End-user API mode, enter:
+    - API Key (`sk-...`)
+    - Device ID
+5. For legacy Cloud mode, enter your Tuya IoT Platform credentials:
     - Access ID
     - Access Secret
     - Device ID
-5. For Local mode: switch the Connection Type to “Local” and enter:
+6. For Local mode, switch the Connection Type to “Local” and enter:
     - Device IP
     - Local Key
     - Protocol (e.g. 3.3 / 3.4)

--- a/custom_components/tuya_heat_pump/config_flow.py
+++ b/custom_components/tuya_heat_pump/config_flow.py
@@ -14,6 +14,7 @@ from .const import (
     DOMAIN,
     CONF_ACCESS_ID,
     CONF_ACCESS_KEY,
+    CONF_API_KEY,
     CONF_DEVICE_ID,
     CONF_REGION,
     CONF_SCAN_INTERVAL,
@@ -27,6 +28,9 @@ from .const import (
     PROTOCOL_OPTIONS,
     CONF_USER_CODE,
     CONF_SHARING_TOKEN_INFO,
+    CONNECTION_CLOUD,
+    CONNECTION_CLOUD_END_USER,
+    CONNECTION_LOCAL,
 )
 from .coordinator import TuyaScaleDataUpdateCoordinator
 from .sharing_mqtt import SharingQRLogin
@@ -36,20 +40,33 @@ _LOGGER = logging.getLogger(__name__)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
-        vol.Required(CONF_ACCESS_ID): str,
-        vol.Required(CONF_ACCESS_KEY): str,
+        vol.Optional(CONF_ACCESS_ID): str,
+        vol.Optional(CONF_ACCESS_KEY): str,
+        vol.Optional(CONF_API_KEY): str,
         vol.Required(CONF_DEVICE_ID): str,
-        vol.Required(CONF_REGION, default=DEFAULT_REGION): selector.SelectSelector(
+        vol.Optional(CONF_REGION, default=DEFAULT_REGION): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=list(REGIONS.keys()),
                 mode=selector.SelectSelectorMode.DROPDOWN
             )
         ),
-        vol.Required(CONF_CONNECTION_TYPE, default="cloud"): selector.SelectSelector(
+        vol.Required(
+            CONF_CONNECTION_TYPE, default=CONNECTION_CLOUD_END_USER
+        ): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=[
-                    selector.SelectOptionDict(value="cloud", label="Cloud (Recommended for most users)"),
-                    selector.SelectOptionDict(value="local", label="Local (Faster, no API limits)")
+                    selector.SelectOptionDict(
+                        value=CONNECTION_CLOUD_END_USER,
+                        label="Cloud End-user API (sk- API key)",
+                    ),
+                    selector.SelectOptionDict(
+                        value=CONNECTION_CLOUD,
+                        label="Cloud IoT Platform (Access ID / Secret)",
+                    ),
+                    selector.SelectOptionDict(
+                        value=CONNECTION_LOCAL,
+                        label="Local (Faster, no API limits)",
+                    ),
                 ],
                 mode=selector.SelectSelectorMode.DROPDOWN
             )
@@ -119,13 +136,22 @@ async def validate_input(hass: HomeAssistant, data: dict, connection_type: str) 
         },
     )()
 
-    if connection_type == "cloud":
+    if connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER):
+        if connection_type == CONNECTION_CLOUD_END_USER:
+            api_key = data.get(CONF_API_KEY, "")
+            if not api_key.startswith("sk-"):
+                raise InvalidAuth("A Tuya API key beginning with sk- is required")
+        elif not data.get(CONF_ACCESS_ID) or not data.get(CONF_ACCESS_KEY):
+            raise InvalidAuth("Access ID and Access Secret are required")
+
         coordinator = TuyaScaleDataUpdateCoordinator(hass, mock_config)
         try:
             # Token ve device info almayı dene
-            if not coordinator.access_token:
+            if connection_type == CONNECTION_CLOUD and not coordinator.access_token:
                 await coordinator._get_token()
-            await coordinator.get_device_info()
+            device_info = await coordinator.get_device_info()
+            if not device_info:
+                raise CannotConnect("Device was not found or is not accessible")
         except Exception as err:
             _LOGGER.error("Cloud validation error: %s", err)
             if "token" in str(err).lower() or "auth" in str(err).lower():
@@ -163,7 +189,7 @@ class TuyaHeatpumpOptionsFlow(config_entries.OptionsFlow):
 
     async def async_step_init(self, user_input=None):
         """Manage the options."""
-        if self.connection_type == "cloud":
+        if self.connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER):
             return await self.async_step_cloud_options()
         else:
             return await self.async_step_local_options()
@@ -274,7 +300,7 @@ class TuyaHeatpumpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             self.user_data = user_input
             self.connection_type = user_input[CONF_CONNECTION_TYPE]
-            if self.connection_type == "cloud":
+            if self.connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER):
                 return await self.async_step_cloud_options()
             else:
                 return await self.async_step_local()
@@ -295,7 +321,9 @@ class TuyaHeatpumpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 return await self.async_step_cloud_qr()
 
             try:
-                info = await validate_input(self.hass, full_data, "cloud")
+                info = await validate_input(
+                    self.hass, full_data, self.connection_type
+                )
                 await self.async_set_unique_id(full_data[CONF_DEVICE_ID])
                 
                 # Check if device is already configured
@@ -338,7 +366,9 @@ class TuyaHeatpumpConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             if success and token_info:
                 full_data = {**self.user_data, CONF_SHARING_TOKEN_INFO: token_info}
                 try:
-                    info = await validate_input(self.hass, full_data, "cloud")
+                    info = await validate_input(
+                        self.hass, full_data, self.connection_type
+                    )
                     await self.async_set_unique_id(full_data[CONF_DEVICE_ID])
                     try:
                         self._abort_if_unique_id_configured()

--- a/custom_components/tuya_heat_pump/const.py
+++ b/custom_components/tuya_heat_pump/const.py
@@ -21,11 +21,15 @@ CONF_SCAN_INTERVAL = "scan_interval"
 # Configuration
 CONF_ACCESS_ID = "access_id"
 CONF_ACCESS_KEY = "access_key"
+CONF_API_KEY = "api_key"
 CONF_DEVICE_ID = "device_id"
 CONF_REGION = "region"
 
 # Yeni
 CONF_CONNECTION_TYPE = "connection_type"
+CONNECTION_CLOUD = "cloud"
+CONNECTION_CLOUD_END_USER = "cloud_end_user"
+CONNECTION_LOCAL = "local"
 CONF_IP = "ip"
 CONF_LOCAL_KEY = "local_key"
 CONF_PROTOCOL = "protocol"
@@ -60,6 +64,19 @@ REGIONS = {
 TOKEN_PATH = "/v1.0/token?grant_type=1"
 DEVICE_DATA_PATH = "/v2.0/cloud/thing/{device_id}/shadow/properties"
 DEVICE_COMMAND_PATH = "/v2.0/cloud/thing/{device_id}/shadow/properties/issue"  # ← Değişiklik: v2.0 komut gönderme endpoint'i
+END_USER_DEVICE_DETAIL_PATH = "/v1.0/end-user/devices/{device_id}/detail"
+END_USER_DEVICE_MODEL_PATH = "/v1.0/end-user/devices/{device_id}/model"
+END_USER_DEVICE_COMMAND_PATH = "/v1.0/end-user/devices/{device_id}/shadow/properties/issue"
+
+API_KEY_REGIONS = {
+    "AY": "https://openapi.tuyacn.com",
+    "AZ": "https://openapi.tuyaus.com",
+    "EU": "https://openapi.tuyaeu.com",
+    "IN": "https://openapi.tuyain.com",
+    "UE": "https://openapi-ueaz.tuyaus.com",
+    "WE": "https://openapi-weaz.tuyaeu.com",
+    "SG": "https://openapi-sg.iotbing.com",
+}
 
 # Device Info
 DEFAULT_NAME = "Tuya Heat Pump"

--- a/custom_components/tuya_heat_pump/coordinator.py
+++ b/custom_components/tuya_heat_pump/coordinator.py
@@ -28,6 +28,7 @@ from .const import (
     DEVICE_COMMAND_PATH,
     CONF_ACCESS_ID,
     CONF_ACCESS_KEY,
+    CONF_API_KEY,
     CONF_DEVICE_ID,
     CONF_REGION,
     CONF_CONNECTION_TYPE,
@@ -40,6 +41,12 @@ from .const import (
     DEFAULT_MANUFACTURER,
     DEFAULT_MODEL,
     CONF_USER_CODE,
+    CONNECTION_CLOUD,
+    CONNECTION_CLOUD_END_USER,
+    END_USER_DEVICE_DETAIL_PATH,
+    END_USER_DEVICE_MODEL_PATH,
+    END_USER_DEVICE_COMMAND_PATH,
+    API_KEY_REGIONS,
 )
 import tinytuya
 from .model_loader import load_model_mapping, async_load_model_mapping
@@ -70,7 +77,7 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
         """Initialize the coordinator."""
         self.connection_type = config_entry.data.get(CONF_CONNECTION_TYPE, "cloud")
        
-        if self.connection_type == "cloud":
+        if self.connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER):
             scan_interval = timedelta(
                 minutes=config_entry.options.get(
                     CONF_SCAN_INTERVAL,
@@ -134,12 +141,13 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
         # Cloud kimlik bilgileri - her iki modda da tutuluyor (local'da model ID için gerekli)
         self.access_id = config_entry.data.get(CONF_ACCESS_ID)
         self.access_key = config_entry.data.get(CONF_ACCESS_KEY)
+        self.api_key = config_entry.data.get(CONF_API_KEY)
         self.region = config_entry.data.get(CONF_REGION)
-        self.api_endpoint = REGIONS.get(self.region)
+        self.api_endpoint = self._resolve_api_endpoint()
 
         self.access_token = None
 
-        if self.connection_type == "cloud":
+        if self.connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER):
             pass
 
         else:
@@ -218,6 +226,29 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
             except Exception as err:
                 _LOGGER.error("Failed to initialize TinyTuya device: %s", err)
                 self.local_device = None
+
+    def _resolve_api_endpoint(self) -> str | None:
+        """Resolve the correct Tuya endpoint for the selected auth mode."""
+        if self.connection_type == CONNECTION_CLOUD_END_USER:
+            if not self.api_key or not self.api_key.startswith("sk-"):
+                return None
+            return API_KEY_REGIONS.get(self.api_key[3:5].upper())
+        return REGIONS.get(self.region)
+
+    @property
+    def _is_end_user_cloud(self) -> bool:
+        return self.connection_type == CONNECTION_CLOUD_END_USER
+
+    @property
+    def _is_cloud(self) -> bool:
+        return self.connection_type in (CONNECTION_CLOUD, CONNECTION_CLOUD_END_USER)
+
+    def _end_user_headers(self) -> dict[str, str]:
+        if not self.api_key:
+            raise ConfigEntryAuthFailed("Missing Tuya end-user API key")
+        if not self.api_endpoint:
+            raise ConfigEntryAuthFailed("Unsupported Tuya API key region prefix")
+        return {"Authorization": f"Bearer {self.api_key}"}
 
     # ============================================================================
     # YARDIMCI METODLAR
@@ -383,7 +414,7 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
         SONRA çağrılmalı — SharingMQTT.async_start() model_mapping'e
         muhtaç, local moddaki _listen_loop'un aksine bu raceyi tolere
         edemez."""
-        if self.connection_type != "cloud" or not self.config_entry.data.get(CONF_USER_CODE):
+        if not self._is_cloud or not self.config_entry.data.get(CONF_USER_CODE):
             return
 
         from .sharing_mqtt import SharingMQTT
@@ -562,8 +593,32 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def get_device_info(self) -> dict:
         """Get device information."""
-        if self.connection_type == "cloud":
+        if self._is_cloud:
             try:
+                if self._is_end_user_cloud:
+                    path = END_USER_DEVICE_DETAIL_PATH.format(device_id=self.device_id)
+                    response = await self.hass.async_add_executor_job(
+                        make_api_request,
+                        f"{self.api_endpoint}{path}",
+                        self._end_user_headers(),
+                    )
+                    result = response.json()
+                    if not result.get("success", False):
+                        raise ConfigEntryAuthFailed(
+                            result.get("msg", ERROR_AUTH)
+                        )
+                    device_data = result["result"]
+                    self.device_name = device_data.get("name", DEFAULT_NAME)
+                    product_name = device_data.get("product_name", DEFAULT_MODEL)
+                    self.is_online = device_data.get("online", True)
+                    self.device_info = DeviceInfo(
+                        identifiers={(DOMAIN, self.device_id)},
+                        name=self.device_name,
+                        manufacturer=DEFAULT_MANUFACTURER,
+                        model=product_name,
+                    )
+                    return device_data
+
                 if not self.access_token:
                     await self._get_token()
                   
@@ -644,6 +699,34 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
         # ────────────────────────────────────────────────────────────────────────
 
         try:
+            if self._is_end_user_cloud:
+                path = END_USER_DEVICE_MODEL_PATH.format(device_id=self.device_id)
+                response = await self.hass.async_add_executor_job(
+                    make_api_request,
+                    f"{self.api_endpoint}{path}",
+                    self._end_user_headers(),
+                )
+                result = response.json()
+                if not result.get("success", False):
+                    raise UpdateFailed(result.get("msg", ERROR_CONN))
+                model_str = result["result"].get("model", "{}")
+                model_info = json.loads(model_str) if model_str else {}
+                self.model_id = model_info.get("modelId")
+                self.model_mapping = await async_load_model_mapping(
+                    self.hass, self.model_id
+                )
+                self._build_dp_mapping()
+                if self.model_id:
+                    self.hass.config_entries.async_update_entry(
+                        self.config_entry,
+                        data={
+                            **self.config_entry.data,
+                            "cached_model_id": self.model_id,
+                            "cached_model_device_id": self.device_id,
+                        },
+                    )
+                return model_info
+
             if not self.access_token:
                 _LOGGER.info("Token yok → token alınıyor...")
                 await self._get_token()
@@ -718,7 +801,39 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
     async def send_command(self, code: str, value: Any) -> bool:
         """Send command to device - local için debounce ile en son değeri gönder."""
         try:
-            if self.connection_type == "cloud":
+            if self._is_cloud:
+                if self._is_end_user_cloud:
+                    path = END_USER_DEVICE_COMMAND_PATH.format(
+                        device_id=self.device_id
+                    )
+                    body_dict = {"properties": json.dumps({code: value})}
+                    response = await self.hass.async_add_executor_job(
+                        make_api_request,
+                        f"{self.api_endpoint}{path}",
+                        {
+                            **self._end_user_headers(),
+                            "Content-Type": "application/json",
+                        },
+                        "POST",
+                        body_dict,
+                    )
+                    result = response.json()
+                    if not result.get("success", False):
+                        _LOGGER.error(
+                            "End-user command failed for %s: %s",
+                            code,
+                            result.get("msg", "Unknown error"),
+                        )
+                        return False
+                    self._sent_value_cache[code] = (value, time.time())
+                    if self.data and code in self.data:
+                        self.data[code]["value"] = value
+                        self.data[code]["timestamp"] = int(time.time() * 1000)
+                        self.async_update_listeners()
+                    await asyncio.sleep(2)
+                    await self.async_request_refresh()
+                    return True
+
                 if not self.access_token:
                     await self._get_token()
                 t = str(int(time.time() * 1000))
@@ -885,8 +1000,43 @@ class TuyaScaleDataUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self):
         """Fetch data from Tuya API or local device (Manual Poll)."""
-        if self.connection_type == "cloud":
+        if self._is_cloud:
             try:
+                if self._is_end_user_cloud:
+                    path = END_USER_DEVICE_DETAIL_PATH.format(
+                        device_id=self.device_id
+                    )
+                    response = await self.hass.async_add_executor_job(
+                        make_api_request,
+                        f"{self.api_endpoint}{path}",
+                        self._end_user_headers(),
+                    )
+                    if response.status_code in (401, 403):
+                        raise ConfigEntryAuthFailed(ERROR_AUTH)
+                    result = response.json()
+                    if not result.get("success", False):
+                        raise UpdateFailed(
+                            f"API error: {result.get('msg', '')}"
+                        )
+                    detail = result.get("result") or {}
+                    self.is_online = bool(detail.get("online", False))
+                    current_time = int(time.time() * 1000)
+                    properties = detail.get("properties") or {}
+                    data = {
+                        code: {
+                            "value": value,
+                            "timestamp": current_time,
+                            "type": type(value).__name__,
+                            "last_update": datetime.now().strftime(
+                                "%Y-%m-%d %H:%M:%S"
+                            ),
+                        }
+                        for code, value in properties.items()
+                    }
+                    self._apply_sent_cache(data)
+                    self.async_update_listeners()
+                    return data
+
                 if not self.access_token:
                     await self._get_token()
                 t = str(int(time.time() * 1000))

--- a/custom_components/tuya_heat_pump/models/e4ets8.py
+++ b/custom_components/tuya_heat_pump/models/e4ets8.py
@@ -1,0 +1,70 @@
+"""Model mapping for the AMT-Pool Mini heat pump (e4ets8)."""
+
+MODEL_NAME = "AMT-Pool Mini"
+
+SENSOR_TYPES = {
+    "temp_current": {
+        "dp_id": 3,
+        "code": "temp_current",
+        "name": "Current Temperature",
+        "unit": "°C",
+        "icon": "mdi:thermometer",
+        "device_class": "temperature",
+        "state_class": "measurement",
+    },
+    "fault": {
+        "dp_id": 13,
+        "code": "fault",
+        "name": "Fault Code",
+        "icon": "mdi:alert-circle",
+        "conversion": "value",
+    },
+}
+
+BINARY_SENSOR_TYPES = {
+    "fault": {
+        "dp_id": 13,
+        "code": "fault",
+        "name": "Fault",
+        "device_class": "problem",
+        "conversion": "value != 0",
+    },
+}
+
+SWITCH_TYPES = {
+    "switch": {
+        "dp_id": 1,
+        "code": "switch",
+        "name": "Power",
+        "icon": "mdi:power",
+        "conversion": "value in [1, True, '1', 'true', 'on']",
+    },
+}
+
+NUMBER_TYPES = {
+    "temp_set": {
+        "dp_id": 2,
+        "code": "temp_set",
+        "name": "Target Temperature",
+        "icon": "mdi:thermostat",
+        "unit": "°C",
+        "min_value": 0,
+        "max_value": 40,
+        "step": 1,
+        "api_conversion": "value",
+    },
+}
+
+SELECT_TYPES = {
+    "mode": {
+        "dp_id": 4,
+        "code": "mode",
+        "name": "Operating Mode",
+        "icon": "mdi:hvac",
+        "options": {
+            "Heat": "Heating",
+            "Cool": "Cooling",
+            "Auto": "Automatic",
+        },
+    },
+}

--- a/custom_components/tuya_heat_pump/strings.json
+++ b/custom_components/tuya_heat_pump/strings.json
@@ -4,10 +4,11 @@
         "step": {
             "user": {
                 "title": "Tuya Heat Pump Setup",
-                "description": "Enter your Tuya IoT Platform credentials and select connection type\n\n• Cloud: Recommended for most users, works over the internet\n• Local: Faster response, no API limits, requires device on local network\n\nFor MQTT (instant updates, optional): find the User Code in your Tuya app under Me → Settings → Account and Security → User Code and enter it below. How well this works varies by device — some devices get everything instantly, others are limited by Tuya's own restrictions (the integration automatically falls back to regular polling in that case). Leave it blank to skip this step entirely — everything else works exactly the same either way.",
+                "description": "Select a connection type and enter its credentials.\n\n• Cloud End-user API: enter an sk- API key from tuya.ai\n• Cloud IoT Platform: enter an Access ID and Access Secret\n• Local: enter the LAN details on the next step\n\nOnly fill the credential fields used by the selected connection type.",
                 "data": {
                     "access_id": "Access ID",
                     "access_key": "Access Key",
+                    "api_key": "End-user API Key (sk-...)",
                     "device_id": "Device ID",
                     "region": "Region",
                     "connection_type": "Connection Type",

--- a/custom_components/tuya_heat_pump/translations/en.json
+++ b/custom_components/tuya_heat_pump/translations/en.json
@@ -5,6 +5,7 @@
                 "data": {
                     "access_id": "Access ID",
                     "access_key": "Access Key",
+                    "api_key": "End-user API Key (sk-...)",
                     "device_id": "Device ID",
                     "region": "Region",
                     "connection_type": "Connection Type",
@@ -13,7 +14,7 @@
                 "data_description": {
                     "user_code": "Found in the Tuya app under Me → Settings → Account and Security → User Code. If provided, you'll be asked to scan a QR code after this step to try instant (MQTT push) updates. Note: how well this works varies by device — some devices get everything instantly, others are limited by Tuya's own restrictions (in that case the integration automatically keeps using regular polling instead, nothing breaks)."
                 },
-                "description": "Enter your Tuya IoT Platform credentials and select connection type\n\n• Cloud: Recommended for most users, works over the internet\n• Local: Faster response, no API limits, requires device on local network\n\nFor MQTT (instant updates, optional): find the User Code in your Tuya app under Me → Settings → Account and Security → User Code and enter it below. How well this works varies by device — some devices get everything instantly, others are limited by Tuya's own restrictions (the integration automatically falls back to regular polling in that case). Leave it blank to skip this step entirely — everything else works exactly the same either way.",
+                "description": "Select a connection type and enter its credentials.\n\n• Cloud End-user API: enter an sk- API key from tuya.ai\n• Cloud IoT Platform: enter an Access ID and Access Secret\n• Local: enter the LAN details on the next step\n\nOnly fill the credential fields used by the selected connection type.",
                 "title": "Tuya Heat Pump Setup"
             },
             "local": {

--- a/custom_components/tuya_heat_pump/translations/tr.json
+++ b/custom_components/tuya_heat_pump/translations/tr.json
@@ -5,6 +5,7 @@
                 "data": {
                     "access_id": "Access ID",
                     "access_key": "Access Key",
+                    "api_key": "Son kullanıcı API anahtarı (sk-...)",
                     "device_id": "Cihaz ID",
                     "region": "Bölge",
                     "connection_type": "Bağlantı Türü",

--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,4 @@
 {
-  "name": "Tuya Heat Pump",
-  "homeassistant": "2023.1.0"
+  "name": "Tuya AMT Pool Mini",
+  "homeassistant": "2026.7.4"
 }

--- a/supported_models.md
+++ b/supported_models.md
@@ -4,6 +4,7 @@
 
 |  | Brand / Model | GitHub User | Model File | Issue/PR | Published |
 |---|---------------|-------------|------------|----------|-----------|
+| 41 | AMT-Pool Mini | [@sysam68](https://github.com/sysam68) | [e4ets8](https://github.com/sysam68/tuya_heat_pump/blob/agent/end-user-api-e4ets8/custom_components/tuya_heat_pump/models/e4ets8.py) | — |  |
 | 1 | Arçelik (Beko, Grundig) | [@korkuttum](https://github.com/korkuttum) | [000004wtcv](https://github.com/Korkuttum/tuya_heat_pump/blob/main/custom_components/tuya_heat_pump/models/000004wtcv.py) | — | * |
 | 2 | ACIQ | [@wlatic](https://github.com/wlatic) | [e1kynud8](https://github.com/Korkuttum/tuya_heat_pump/blob/main/custom_components/tuya_heat_pump/models/e1kynud8.py) | [#59](https://github.com/Korkuttum/tuya_heat_pump/issues/59) | * |
 | 3 | Adlar Castra | [@rznq0q](https://github.com/rznq0q) | [000004u5nz](https://github.com/Korkuttum/tuya_heat_pump/blob/main/custom_components/tuya_heat_pump/models/000004u5nz.py) | [#4](https://github.com/Korkuttum/tuya_heat_pump/issues/4) | * |


### PR DESCRIPTION
## What changed

- add a `cloud_end_user` connection mode using `Authorization: Bearer sk-...`
- infer all seven supported Tuya data centers from the API-key prefix
- use the end-user detail, model, and property-command endpoints
- normalize dictionary-shaped end-user properties for existing Home Assistant entities
- preserve the legacy IoT Cloud and local connection modes
- add an `e4ets8` model profile for the AMT-Pool Mini
- update setup strings and documentation

## Why

The AMT-Pool Mini is available through Tuya's 2C end-user API but cannot authenticate through the integration's legacy Access ID / Access Secret flow. Its model ID was also absent, causing the unrelated default mapping to load.

## Validation

- parsed all Python files successfully
- validated all integration JSON files
- validated the live read-only end-user detail and model calls against an AMT-Pool Mini
- confirmed model ID `e4ets8` and properties `switch`, `temp_set`, `temp_current`, `mode`, and `fault`
- `git diff --check` passed
- no write command was sent to the device during validation