### PR TITLE
docs: clarify compatibility and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,139 +1,206 @@
-# Tuya Heat Pump - Home Assistant Integration
+# Tuya Heat Pump for Home Assistant
 
-<img src="https://raw.githubusercontent.com/Korkuttum/tuya_heat_pump/main/images/heatpump.webp" width="200">
+<p align="center">
+  <img src="https://raw.githubusercontent.com/Korkuttum/tuya_heat_pump/main/images/heatpump.webp" alt="Tuya Heat Pump" width="200">
+</p>
 
- ⚠️ **Note:**  
-> This integration has only been tested with the heat pump brands listed below.  
-> If your heat pump is a different brand and the integration does not work, please run the script at the following link and share the generated file with me:  
-> [tuya_api_test.py](https://github.com/Korkuttum/tuya_heat_pump/blob/main/test/tuya_api_test.py)
-### Supported Brands
-📋 **[Detailed list](https://github.com/Korkuttum/tuya_heat_pump/blob/main/supported_models.md)**
-- Arçelik (Beko, Grundig)
-- ACIQ
-- Adlar Castra
-- Adlar Castra Domestic
-- Alps Exclusive
-- Aquark
-- Aquastrong 
-- Aquatech X6
-- Aquatech X6 320L
-- Cordivari Vestalis
-- Della
-- Ecologic Ecopool
-- EnviroSun HP+
-- Evoheat 40T
-- Fairland
-- Fairland Inverter Plus
-- Heative Next
-- Inventor Xforce
-- IPS Pool Systems
-- ITS
-- Ivapool
-- Kensol
-- Kushiro (Luqstoff)
-- Mango
-- Mitte Aerotermia
-- MyCond BeeThermic
-- Poolex Dreamline
-- Poolsana
-- Power World
-- Power World PW030
-- Power World R290 Full DC
-- Pure Blue Onyx
-- Reclaim Eco R290
-- Rotenso
-- SolarEast
-- SolarEast BLN
-- Swim&Fun Fjord
-- Water TechniX
-- W'eau
-- W'eau WFI-007
-- Wopoltop
----
+A custom Home Assistant integration for monitoring and controlling supported Tuya-based heat pumps through the Tuya Cloud API or directly over the local network.
 
-This project allows you to control and monitor your Tuya heat pump device through Home Assistant — supports both Cloud and Local (push) connection modes.
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Korkuttum&repository=tuya_heat_pump&category=integration)
 
----
+> [!IMPORTANT]
+> Compatibility depends on the Tuya **Model ID** and datapoint definitions, not only on the brand printed on the heat pump. Rebranded units may share the same controller and model mapping, while two units from the same brand may use different datapoints.
 
-## Prerequisites
+## Features
 
-### Enabling Tuya IoT Cloud Service
+- Cloud connection through the Tuya IoT Platform
+- Local LAN connection through TinyTuya
+- Optional MQTT push updates through the Tuya Smart or Smart Life app
+- Per-model mappings for sensors and controls
+- Automatic fallback to the default mapping when a Model ID is unknown
+- Home Assistant entities for:
+  - sensors and binary sensors
+  - switches
+  - numeric settings
+  - selectable operating modes
+  - text settings, when exposed by the device
+- Cloud commands and local control
+- Configurable cloud polling interval
+- Automatic return to polling if MQTT is unavailable or incomplete
 
-To use this integration, you need to create a project in the Tuya IoT Platform, grant API access, and link your device to the project.
+The exact entities available depend on the model mapping and the datapoints exposed by your device.
 
-**Steps:**
+## Compatibility
 
-1. Log in to ***[Tuya IoT Platform](https://iot.tuya.com/)***.
-2. Go to ***Cloud > Project Management*** and create a new project or select an existing one.
-3. Select the ***Devices*** tab:
-   - If your devices are already listed, proceed to the next step.
-   - If you have no devices yet, open the ***Link App Account*** tab below. Click the ***Add App Account*** button on the right, then select ***Tuya App Account Authorization***. Scan the QR code using your Tuya mobile app and grant permission. Your devices will then appear.
-4. Click on the ***Service API*** tab above, then click the ***Go to Authorize*** button and add the following APIs to your project:
-   - ***IoT Core***
-   - ***Smart Home Basic Service***
-   - ***Device Status Notification***
-   - ***Authorization Token Management***
-5. Retrieve your ***Access ID*** and ***Access Secret*** from the project panel.
+See the [detailed supported-model list](supported_models.md) for tested brands, models, Tuya Model IDs, and the related issue or pull request.
 
-> ⚠️ **Important:** The integration will not work without API authorization and device linking.
+An unlisted heat pump may still work if it uses the same Tuya Model ID and datapoint layout as a supported device. If no matching model file exists, the integration loads the generic `default` mapping. A successful installation therefore does not necessarily mean that every entity is correctly mapped.
 
----
+If your device is not listed or produces missing, unavailable, or incorrect entities, follow [Adding support for a new model](#adding-support-for-a-new-model).
+
+## Requirements
+
+- Home Assistant 2023.1.0 or newer
+- A Tuya Smart or Smart Life account with the heat pump already paired
+- A Tuya IoT Platform Cloud project linked to that app account
+- The following Tuya project values:
+  - Access ID
+  - Access Secret (shown as **Access Key** in the integration)
+  - Device ID
+  - correct data-center region
+- For local mode:
+  - device IP address
+  - Local Key
+  - Tuya protocol version: 3.1, 3.3, 3.4, or 3.5
+  - Home Assistant and the heat pump on the same local network
+
+> [!NOTE]
+> The setup form currently requests the Tuya Cloud credentials for both connection modes. In local mode, they are used to retrieve device information and select the correct model mapping; normal status updates and commands then use the LAN connection.
+
+## Configure the Tuya IoT Platform
+
+1. Sign in to the [Tuya IoT Platform](https://iot.tuya.com/).
+2. Open **Cloud > Development** or **Cloud > Project Management**, then create or select a Cloud project.
+3. Use the data center that matches the region of your Tuya Smart or Smart Life account.
+4. Open the project's **Devices** section.
+5. If the heat pump is not listed, open **Link Tuya App Account**, add an app account, and scan the displayed QR code with the mobile app.
+6. In **Service API**, authorize:
+   - IoT Core
+   - Smart Home Basic Service
+   - Device Status Notification
+   - Authorization Token Management
+7. Copy the project's **Access ID** and **Access Secret**.
+8. Copy the heat pump's **Device ID** from the device list.
+
+If token creation or device discovery fails, first verify the selected region, API authorizations, and app-account link.
 
 ## Installation
 
-[![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Korkuttum&repository=tuya_heat_pump&category=integration)
+### HACS
 
-### Method 1: Installation via HACS (Recommended)
+1. Install [HACS](https://www.hacs.xyz/) if it is not already available.
+2. Open the button below or add this repository as a custom integration repository.
+3. Download **Tuya Heat Pump**.
+4. Restart Home Assistant.
 
-1. Make sure you have **HACS** installed in your Home Assistant instance.
-2. Go to **HACS** → **Integrations**.
-3. Click the search icon in the top right and search for **"Tuya Heat Pump"**.
-4. Click **Download** on the integration.
-5. Restart Home Assistant.
+[![Open in HACS](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=Korkuttum&repository=tuya_heat_pump&category=integration)
 
-### Method 2: Manual Installation
+### Manual installation
 
-1. Download the latest release from the [GitHub repository](https://github.com/Korkuttum/tuya_heat_pump).
-2. Extract the files and copy the `tuya_heat_pump` folder into your Home Assistant `custom_components` directory.
+1. Download the latest repository release.
+2. Copy `custom_components/tuya_heat_pump` into your Home Assistant `custom_components` directory.
 3. Restart Home Assistant.
----
+
+The resulting path must be:
+
+```text
+<config>/custom_components/tuya_heat_pump/manifest.json
+```
 
 ## Configuration
 
-After installation, restart Home Assistant and follow these steps:
+In Home Assistant:
 
-1. Go to “Settings > Devices & Services”.
-2. Click “Add Integration”.
-3. Search for and select “Tuya Heat Pump”.
-4. For Cloud mode: enter your Tuya IoT Platform credentials:
-    - Access ID
-    - Access Secret
-    - Device ID
-5. For Local mode: switch the Connection Type to “Local” and enter:
-    - Device IP
-    - Local Key
-    - Protocol (e.g. 3.3 / 3.4)
-    - Device ID
+1. Open **Settings > Devices & services**.
+2. Select **Add integration**.
+3. Search for **Tuya Heat Pump**.
+4. Enter the Access ID, Access Key, Device ID, and region.
+5. Select a connection type.
+6. Complete the fields for the selected mode.
 
----
+### Connection modes
 
-## Notes
+| Mode | Data path | Additional values | Update behavior | Main trade-off |
+| --- | --- | --- | --- | --- |
+| Cloud | Tuya IoT API | None beyond the common Cloud credentials | Polling, 3 minutes by default | Works remotely but depends on Tuya Cloud and API availability |
+| Local | Direct LAN connection | IP, Local Key, protocol version | Local status/push handling | Fast and avoids Cloud API limits for normal operation, but requires LAN reachability and valid local credentials |
+| Cloud + MQTT | Tuya IoT API plus Tuya app sharing | Optional User Code and QR approval | Push when coverage is sufficient; polling remains as fallback | Update coverage varies by device and Tuya's standard instruction set |
 
-- You can monitor and control features like temperature, operation mode, and fan speed.
-- Easily use in automations and dashboards.
+The cloud polling interval can be changed from the integration options between 1 and 60 minutes.
 
----
+### Optional MQTT updates
 
-## Support My Work
+MQTT support is optional and only offered during Cloud setup.
 
-If you find this integration helpful, consider supporting the development:
+1. In the Tuya Smart or Smart Life app, open **Me > Settings > Account and Security > User Code**.
+2. Enter that User Code in the integration setup form.
+3. Scan the Home Assistant QR code from the Tuya app using **+ > Scan**.
+4. Return to Home Assistant and submit the form.
+
+If MQTT exposes every datapoint required by the selected model, regular polling is paused while MQTT remains healthy. If coverage is incomplete, MQTT only triggers an immediate refresh and polling continues. If the MQTT connection drops, the integration automatically restores polling.
+
+Leave the User Code blank to use standard polling without MQTT.
+
+## Adding support for a new model
+
+Use the diagnostic script when your heat pump is not listed or its entities are incorrectly mapped:
+
+[`test/tuya_api_test.py`](test/tuya_api_test.py)
+
+The script:
+
+1. requests your Access ID, Access Key, API region, and Device ID;
+2. obtains a temporary Tuya Cloud token;
+3. reads the device shadow properties;
+4. reads the Tuya device model definition;
+5. writes the result to a timestamped `tuya_device_data_*.txt` file.
+
+Run it on a computer with Python 3 and the `requests` package:
+
+```bash
+python3 -m pip install requests
+python3 test/tuya_api_test.py
+```
+
+Review the generated file before attaching it to a [new GitHub issue](https://github.com/Korkuttum/tuya_heat_pump/issues/new). Include the heat-pump brand and exact commercial model.
+
+> [!CAUTION]
+> Never publish your Access ID, Access Secret/Key, Local Key, access token, or Tuya account credentials. The script does not intentionally write the Access Key or token to its output file, but the report does contain the Device ID, current property values, and the complete device model definition. Redact anything you do not want to share.
+
+## Troubleshooting
+
+### Authentication failed
+
+Check that:
+
+- Access ID and Access Key belong to the same Tuya Cloud project;
+- the selected region matches the app account's data center;
+- the required Service APIs are authorized;
+- the app account is still linked to the Cloud project;
+- the Device ID belongs to that linked account.
+
+### Local connection failed
+
+Check that:
+
+- the device IP has not changed;
+- Home Assistant can reach that IP;
+- the Local Key is current;
+- the selected protocol version matches the device;
+- VLAN and firewall rules allow traffic between Home Assistant and the heat pump.
+
+Re-pairing or removing a Tuya device can change its Local Key.
+
+### Setup succeeds but entities are missing
+
+This usually indicates an unknown Model ID or a datapoint mismatch. Compare the device Model ID with [supported_models.md](supported_models.md), then generate a diagnostic report as described above.
+
+### MQTT does not provide every update
+
+This can be normal. Tuya may expose only part of a device through its standard instruction set. The integration keeps polling whenever MQTT coverage is insufficient, so control and monitoring continue without relying exclusively on push events.
+
+## Support
+
+For bugs and model-support requests, use the [GitHub issue tracker](https://github.com/Korkuttum/tuya_heat_pump/issues).
+
+If you find this integration useful, you can support its development:
 
 [![Become a Patreon](https://img.shields.io/badge/Become_a-Patron-red.svg?style=for-the-badge&logo=patreon)](https://www.patreon.com/korkuttum)
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+This project is licensed under the [MIT License](LICENSE).
 
 ## Disclaimer
 
-This integration is an independent project and is not affiliated with, endorsed by, or connected to Tuya Inc. in any way. This is a community project provided "as is" without warranty of any kind. Use at your own risk.
+This is an independent community project and is not affiliated with, endorsed by, or connected to Tuya Inc. It is provided as-is, without warranty. Use it at your own risk.


### PR DESCRIPTION
## What changed

- reorganized the README around features, compatibility, requirements, installation, configuration, and troubleshooting
- clarified that compatibility is determined by the Tuya Model ID and datapoint mapping rather than the commercial brand alone
- documented Cloud, Local, and optional MQTT update behavior from the current implementation
- documented the actual Home Assistant entity platforms exposed by the integration
- explained the default-model fallback and the implications of an unknown model
- expanded the new-model diagnostic workflow and added explicit secret-handling guidance

## Why

The previous README duplicated the supported-model list, described connection modes only briefly, and did not cover the optional MQTT flow or the risks of an unknown model mapping. It also left unclear that the setup form requires Tuya Cloud credentials before local connection details are entered.

## User impact

Users can now determine compatibility more accurately, choose a connection mode with clearer expectations, configure MQTT when appropriate, and collect model diagnostics without accidentally publishing credentials.

## Validation

- checked the documented requirements against `hacs.json` and `manifest.json`
- checked the configuration fields and polling limits against `config_flow.py`, `const.py`, and the English translations
- checked local/cloud behavior and model fallback against `coordinator.py` and `model_loader.py`
- checked MQTT fallback behavior against `sharing_mqtt.py`
- ran `git diff --check`
